### PR TITLE
Add support for Nicira Openflow extension

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -35,19 +35,19 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/common",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/openflow13",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/protocol",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libOpenflow/util",
-			"Rev": "cb1835d1c11f5810c2fcf404a6d1eb907168f951"
+			"Rev": "a32467f65a1727309931f5c341ab7d867e624f3c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libovsdb",

--- a/ofctrl/fgraphEmptyElem.go
+++ b/ofctrl/fgraphEmptyElem.go
@@ -1,0 +1,26 @@
+package ofctrl
+
+import (
+	"github.com/contiv/libOpenflow/openflow13"
+)
+
+// This file implements the forwarding graph API for empty element. It will return
+// InstrActions as the value of GetFlowInstr, but without any reserved actions.
+
+type EmptyElem struct {
+}
+
+// Fgraph element type for the NXOutput
+func (self *EmptyElem) Type() string {
+	return "empty"
+}
+
+// instruction set for NXOutput element
+func (self *EmptyElem) GetFlowInstr() openflow13.Instruction {
+	instr := openflow13.NewInstrApplyActions()
+	return instr
+}
+
+func NewEmptyElem() *EmptyElem {
+	return new(EmptyElem)
+}

--- a/ofctrl/fgraphFlow.go
+++ b/ofctrl/fgraphFlow.go
@@ -921,6 +921,13 @@ func (self *Flow) install() error {
 	return nil
 }
 
+// updateInstallStatus changes isInstalled value.
+func (self *Flow) UpdateInstallStatus(installed bool) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	self.isInstalled = installed
+}
+
 // Set Next element in the Fgraph. This determines what actions will be
 // part of the flow's instruction set
 func (self *Flow) Next(elem FgraphElem) error {

--- a/ofctrl/fgraphGroup.go
+++ b/ofctrl/fgraphGroup.go
@@ -1,0 +1,107 @@
+package ofctrl
+
+import (
+	"github.com/contiv/libOpenflow/openflow13"
+)
+
+type GroupType int
+
+const (
+	GroupAll GroupType = iota
+	GroupSelect
+	GroupIndirect
+	GroupFF
+)
+
+type Group struct {
+	Switch      *OFSwitch
+	ID          uint32
+	GroupType   GroupType
+	Buckets     []*openflow13.Bucket
+	isInstalled bool
+}
+
+func (self *Group) Type() string {
+	return "group"
+}
+
+func (self *Group) GetFlowInstr() openflow13.Instruction {
+	groupInstr := openflow13.NewInstrApplyActions()
+	groupAct := openflow13.NewActionGroup(self.ID)
+	// Add group action to the instruction
+	groupInstr.AddAction(groupAct, false)
+	return groupInstr
+}
+
+func (self *Group) AddBuckets(buckets ...*openflow13.Bucket) {
+	if self.Buckets == nil {
+		self.Buckets = make([]*openflow13.Bucket, 0)
+	}
+	self.Buckets = append(self.Buckets, buckets...)
+	if self.isInstalled {
+		self.Install()
+	}
+}
+
+func (self *Group) ResetBuckets(buckets ...*openflow13.Bucket) {
+	self.Buckets = make([]*openflow13.Bucket, 0)
+	self.Buckets = append(self.Buckets, buckets...)
+	if self.isInstalled {
+		self.Install()
+	}
+}
+
+func (self *Group) Install() error {
+	groupMod := openflow13.NewGroupMod()
+	groupMod.GroupId = self.ID
+
+	switch self.GroupType {
+	case GroupAll:
+		groupMod.Type = openflow13.OFPGT_ALL
+	case GroupSelect:
+		groupMod.Type = openflow13.OFPGT_SELECT
+	case GroupIndirect:
+		groupMod.Type = openflow13.OFPGT_INDIRECT
+	case GroupFF:
+		groupMod.Type = openflow13.OFPGT_FF
+	}
+
+	for _, bkt := range self.Buckets {
+		// Add the bucket to group
+		groupMod.AddBucket(*bkt)
+	}
+
+	if self.isInstalled {
+		groupMod.Command = openflow13.OFPGC_MODIFY
+	}
+	self.Switch.Send(groupMod)
+
+	// Mark it as installed
+	self.isInstalled = true
+
+	return nil
+}
+
+func (self *Group) Delete() error {
+	groupMod := openflow13.NewGroupMod()
+	groupMod.GroupId = self.ID
+
+	if self.isInstalled {
+		groupMod.Command = openflow13.OFPGC_DELETE
+		self.Switch.Send(groupMod)
+	}
+
+	// Mark it as unInstalled
+	self.isInstalled = false
+
+	// Delete group from switch cache
+	return self.Switch.DeleteGroup(self.ID)
+}
+
+func newGroup(id uint32, groupType GroupType, ofSwitch *OFSwitch) *Group {
+	return &Group{
+		ID:        id,
+		GroupType: groupType,
+		Switch:    ofSwitch,
+	}
+}

--- a/ofctrl/fgraphGroup.go
+++ b/ofctrl/fgraphGroup.go
@@ -83,16 +83,14 @@ func (self *Group) Install() error {
 }
 
 func (self *Group) Delete() error {
-	groupMod := openflow13.NewGroupMod()
-	groupMod.GroupId = self.ID
-
 	if self.isInstalled {
+		groupMod := openflow13.NewGroupMod()
+		groupMod.GroupId = self.ID
 		groupMod.Command = openflow13.OFPGC_DELETE
 		self.Switch.Send(groupMod)
+		// Mark it as unInstalled
+		self.isInstalled = false
 	}
-
-	// Mark it as unInstalled
-	self.isInstalled = false
 
 	// Delete group from switch cache
 	return self.Switch.DeleteGroup(self.ID)

--- a/ofctrl/fgraphNXOutput.go
+++ b/ofctrl/fgraphNXOutput.go
@@ -1,0 +1,43 @@
+package ofctrl
+
+import "github.com/contiv/libOpenflow/openflow13"
+
+// This file implements the forwarding graph API for output to NX register element
+
+type NXOutput struct {
+	field      *openflow13.MatchField // Target OXM/OXX field
+	fieldRange *openflow13.NXRange    // Field range of target register to resubmit
+}
+
+// Fgraph element type for the NXOutput
+func (self *NXOutput) Type() string {
+	return "NxOutput"
+}
+
+// instruction set for NXOutput element
+func (self *NXOutput) GetFlowInstr() openflow13.Instruction {
+	outputInstr := openflow13.NewInstrApplyActions()
+	outputAct := self.GetNXOutputAction()
+	outputInstr.AddAction(outputAct, false)
+	return outputInstr
+}
+
+// Return a NXOutput action
+func (self *NXOutput) GetNXOutputAction() openflow13.Action {
+	ofsNbits := self.fieldRange.ToOfsBits()
+	targetField := self.field
+	// Create NX output Register action
+	return openflow13.NewOutputFromField(targetField, ofsNbits)
+}
+
+func NewNXOutput(name string, start int, end int) (*NXOutput, error) {
+	field, err := openflow13.FindFieldHeaderByName(name, false)
+	if err != nil {
+		return nil, err
+	}
+	fieldRange := openflow13.NewNXRange(start, end)
+	return &NXOutput{
+		field:      field,
+		fieldRange: fieldRange,
+	}, nil
+}

--- a/ofctrl/fgraphNXOutput.go
+++ b/ofctrl/fgraphNXOutput.go
@@ -5,8 +5,8 @@ import "github.com/contiv/libOpenflow/openflow13"
 // This file implements the forwarding graph API for output to NX register element
 
 type NXOutput struct {
-	field      *openflow13.MatchField // Target OXM/OXX field
-	fieldRange *openflow13.NXRange    // Field range of target register to resubmit
+	field      *openflow13.MatchField // Target OXM/NXM field
+	fieldRange *openflow13.NXRange    // Field range of target register to output
 }
 
 // Fgraph element type for the NXOutput

--- a/ofctrl/fgraphOutput.go
+++ b/ofctrl/fgraphOutput.go
@@ -44,6 +44,8 @@ func (self *Output) GetFlowInstr() openflow13.Instruction {
 		outputInstr.AddAction(outputAct, false)
 	case "normal":
 		fallthrough
+	case "inPort":
+		fallthrough
 	case "port":
 		outputAct := openflow13.NewActionOutput(self.portNo)
 		outputInstr.AddAction(outputAct, false)
@@ -65,9 +67,19 @@ func (self *Output) GetOutAction() openflow13.Action {
 		return outputAct
 	case "normal":
 		fallthrough
+	case "inPort":
+		fallthrough
 	case "port":
 		return openflow13.NewActionOutput(self.portNo)
 	}
 
 	return nil
+}
+
+func NewOutputInPort() *Output {
+	return &Output{outputType: "inPort", portNo: openflow13.P_IN_PORT}
+}
+
+func NewOutputNormal() *Output {
+	return &Output{outputType: "normal", portNo: openflow13.P_NORMAL}
 }

--- a/ofctrl/fgraphOutput.go
+++ b/ofctrl/fgraphOutput.go
@@ -83,3 +83,7 @@ func NewOutputInPort() *Output {
 func NewOutputNormal() *Output {
 	return &Output{outputType: "normal", portNo: openflow13.P_NORMAL}
 }
+
+func NewOutputPort(portNo uint32) *Output {
+	return &Output{outputType: "port", portNo: portNo}
+}

--- a/ofctrl/fgraphResubmit.go
+++ b/ofctrl/fgraphResubmit.go
@@ -1,0 +1,41 @@
+package ofctrl
+
+import "github.com/wenyingd/libOpenflow/openflow13"
+
+// This file implements the forwarding graph API for the resubmit element
+
+type Resubmit struct {
+	ofport    uint16 // target ofport to resubmit
+	nextTable uint8  // target table to resubmit
+}
+
+// Fgraph element type for the Resubmit
+func (self *Resubmit) Type() string {
+	return "Resubmit"
+}
+
+// instruction set for resubmit element
+func (self *Resubmit) GetFlowInstr() openflow13.Instruction {
+	outputInstr := openflow13.NewInstrApplyActions()
+	resubmitAct := self.GetResubmitAction()
+	outputInstr.AddAction(resubmitAct, false)
+	return outputInstr
+}
+
+// Return a resubmit action (Used as a last action by flows in the table pipeline)
+func (self *Resubmit) GetResubmitAction() openflow13.Action {
+	if self.ofport == 0 {
+		self.ofport = openflow13.OFPP_IN_PORT
+	}
+	if self.nextTable == 0 {
+		self.nextTable = openflow13.OFPTT_ALL
+	}
+	return openflow13.NewNXActionResubmitTableAction(self.ofport, self.nextTable)
+}
+
+func NewResubmit(inPort uint16, table uint8) *Resubmit {
+	return &Resubmit{
+		ofport:    inPort,
+		nextTable: table,
+	}
+}

--- a/ofctrl/fgraphResubmit.go
+++ b/ofctrl/fgraphResubmit.go
@@ -1,6 +1,6 @@
 package ofctrl
 
-import "github.com/wenyingd/libOpenflow/openflow13"
+import "github.com/contiv/libOpenflow/openflow13"
 
 // This file implements the forwarding graph API for the resubmit element
 
@@ -24,18 +24,20 @@ func (self *Resubmit) GetFlowInstr() openflow13.Instruction {
 
 // Return a resubmit action (Used as a last action by flows in the table pipeline)
 func (self *Resubmit) GetResubmitAction() openflow13.Action {
-	if self.ofport == 0 {
-		self.ofport = openflow13.OFPP_IN_PORT
-	}
-	if self.nextTable == 0 {
-		self.nextTable = openflow13.OFPTT_ALL
-	}
 	return openflow13.NewNXActionResubmitTableAction(self.ofport, self.nextTable)
 }
 
-func NewResubmit(inPort uint16, table uint8) *Resubmit {
-	return &Resubmit{
-		ofport:    inPort,
-		nextTable: table,
+func NewResubmit(inPort *uint16, table *uint8) *Resubmit {
+	resubmit := new(Resubmit)
+	if inPort == nil {
+		resubmit.ofport = openflow13.OFPP_IN_PORT
+	} else {
+		resubmit.ofport = *inPort
 	}
+	if table == nil {
+		resubmit.nextTable = openflow13.OFPTT_ALL
+	} else {
+		resubmit.nextTable = *table
+	}
+	return resubmit
 }

--- a/ofctrl/fgraphSwitch.go
+++ b/ofctrl/fgraphSwitch.go
@@ -103,6 +103,33 @@ func (self *OFSwitch) DefaultTable() *Table {
 	return self.tableDb[0]
 }
 
+// Create a new group. return an error if it already exists
+func (self *OFSwitch) NewGroup(groupId uint32, groupType GroupType) (*Group, error) {
+	// check if the table already exists
+	if self.groupDb[groupId] != nil {
+		return nil, errors.New("Group already exists")
+	}
+
+	// Create a new table
+	group := newGroup(groupId, groupType, self)
+	// Save it in the DB
+	self.groupDb[groupId] = group
+
+	return group, nil
+}
+
+// Delete a group.
+// Return an error if there are flows refer pointing at it
+func (self *OFSwitch) DeleteGroup(groupId uint32) error {
+	delete(self.groupDb, groupId)
+	return nil
+}
+
+// GetGroup Returns a group
+func (self *OFSwitch) GetGroup(groupId uint32) *Group {
+	return self.groupDb[groupId]
+}
+
 // Return a output graph element for the port
 func (self *OFSwitch) OutputPort(portNo uint32) (*Output, error) {
 	self.portMux.Lock()

--- a/ofctrl/fgraphTable.go
+++ b/ofctrl/fgraphTable.go
@@ -56,8 +56,6 @@ func (self *Table) NewFlow(match FlowMatch) (*Flow, error) {
 	flow.Table = self
 	flow.Match = match
 	flow.isInstalled = false
-	flow.FlowID = globalFlowID // FIXME: need a better id allocation
-	globalFlowID += 1
 	flow.flowActions = make([]*FlowAction, 0)
 
 	log.Debugf("Creating new flow for match: %+v", match)

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -531,8 +531,8 @@ func TestMatchSetTunnelId(t *testing.T) {
 
 // TestMatchSetIpFields verifies match & set for ip fields
 func TestMatchSetIpFields(t *testing.T) {
-	ipSa := net.ParseIP("10.1.1.1")
-	ipDa := net.ParseIP("10.2.1.1")
+	ipSa := net.ParseIP("10.1.1.0")
+	ipDa := net.ParseIP("10.2.1.0")
 	ipAddrMask := net.ParseIP("255.255.255.0")
 	inPortFlow, err := ofActor.inputTable.NewFlow(FlowMatch{
 		Priority:  100,

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -412,8 +412,8 @@ func TestSetUnsetDscp(t *testing.T) {
 	}
 
 	// Set vlan and dscp
-	inPortFlow.SetVlan(1)
 	inPortFlow.SetDscp(23)
+	inPortFlow.SetVlan(1)
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -549,8 +549,8 @@ func TestMatchSetIpFields(t *testing.T) {
 	}
 
 	// Set ip src/dst
-	inPortFlow.SetIPField(net.ParseIP("20.1.1.1"), "Src")
 	inPortFlow.SetIPField(net.ParseIP("20.2.1.1"), "Dst")
+	inPortFlow.SetIPField(net.ParseIP("20.1.1.1"), "Src")
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -643,8 +643,8 @@ func TestMatchSetTcpFields(t *testing.T) {
 	}
 
 	// Set TCP src/dst
-	inPortFlow.SetL4Field(4000, "TCPSrc")
 	inPortFlow.SetL4Field(5000, "TCPDst")
+	inPortFlow.SetL4Field(4000, "TCPSrc")
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -686,8 +686,8 @@ func TestMatchSetUdpFields(t *testing.T) {
 	}
 
 	// Set TCP src/dst
-	inPortFlow.SetL4Field(4000, "UDPSrc")
 	inPortFlow.SetL4Field(5000, "UDPDst")
+	inPortFlow.SetL4Field(4000, "UDPSrc")
 
 	// install it
 	err = inPortFlow.Next(ofActor.nextTable)
@@ -876,7 +876,7 @@ func testNXExtensionsWithOFApplication(ofApp OfActor, ovsBr *ovsdbDriver.OvsDriv
 		t.Errorf("Error installing inport flow. Err: %v", err)
 	}
 	matchStr := "priority=100,in_port=5"
-	actionStr := "conjunction(101,2/3),conjunction(100,2/5)"
+	actionStr := "conjunction(100,2/5),conjunction(101,2/3)"
 	tableID := int(ofApp.inputTable.TableId)
 	// verify metadata action exists
 	if !ofctlDumpFlowMatch(brName, tableID, matchStr, actionStr) {
@@ -940,13 +940,13 @@ func testNXExtensionsWithOFApplication(ofApp OfActor, ovsBr *ovsdbDriver.OvsDriv
 	rng4 := openflow13.NewNXRange(0, 31)
 	sMAC, _ := net.ParseMAC("11:11:11:11:11:22")
 	sIP := net.ParseIP("192.168.1.100")
-	_ = flow7.SetARPSpa(sIP)
-	_ = flow7.SetARPSha(sMAC)
-	_ = flow7.SetMacSa(sMAC)
-	_ = flow7.SetARPOper(2)
-	_ = flow7.MoveRegs("NXM_OF_ARP_SPA", "NXM_OF_ARP_TPA", rng4, rng4)
-	_ = flow7.MoveRegs("NXM_NX_ARP_SHA", "NXM_NX_ARP_THA", rng2, rng2)
 	_ = flow7.MoveRegs("NXM_OF_ETH_SRC", "NXM_OF_ETH_DST", rng2, rng2)
+	_ = flow7.MoveRegs("NXM_NX_ARP_SHA", "NXM_NX_ARP_THA", rng2, rng2)
+	_ = flow7.MoveRegs("NXM_OF_ARP_SPA", "NXM_OF_ARP_TPA", rng4, rng4)
+	_ = flow7.SetARPOper(2)
+	_ = flow7.SetMacSa(sMAC)
+	_ = flow7.SetARPSha(sMAC)
+	_ = flow7.SetARPSpa(sIP)
 	verifyFlowInstallAndDelete(t, flow7, NewOutputInPort(), brName, ofApp.inputTable.TableId,
 		"priority=100,arp,in_port=7,arp_op=1",
 		"move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],set_field:2->arp_op,set_field:11:11:11:11:11:22->eth_src,set_field:11:11:11:11:11:22->arp_sha,set_field:192.168.1.100->arp_spa,IN_PORT")


### PR DESCRIPTION
1. Add group support. Group is an implementation of FgraphElem, and support to add buckets
2. Support NX extension of actions: resubmit, output to NX register. These two actions are
   working as implementation of FgraphElem
3. Add EmptyElem to support none following output actions, used for multiple conjunction case
4. Add support for Nicira extended actions: load, move, conjunction, ct
5. Add support for Nicira extented match: regX[m.n], ct_state, ct_mark
6. This change is denpendant on change of libOpenflow to add support for Nicira extensions

Signed-off-by: wenyingd <wenyingd@vmware.com>