### PR TITLE
Support connnect to OVS bridge using named pipe on windows

### DIFF
--- a/ofctrl/dia_linux.go
+++ b/ofctrl/dia_linux.go
@@ -1,0 +1,7 @@
+package ofctrl
+
+import "net"
+
+func DialUnixOrNamedPipe(address string) (net.Conn, error) {
+	return net.Dial("unix", address)
+}

--- a/ofctrl/dial_windows.go
+++ b/ofctrl/dial_windows.go
@@ -1,0 +1,11 @@
+package ofctrl
+
+import (
+	"github.com/Microsoft/go-winio"
+	"net"
+)
+
+// Connect to named pipe
+func DialUnixOrNamedPipe(address string) (net.Conn, error) {
+	return winio.DialPipe(address, nil)
+}

--- a/ofctrl/ofctrl.go
+++ b/ofctrl/ofctrl.go
@@ -124,7 +124,8 @@ func (c *Controller) Listen(port string) {
 
 }
 
-// Connect to Unix Domain Socket file
+// Linux: Connect to Unix Domain Socket file
+// Windows: Connect to named pipe
 func (c *Controller) Connect(sock string) error {
 	if c.connCh == nil {
 		// Construct stop flag for notifying controller to stop connections
@@ -173,7 +174,9 @@ func (c *Controller) Connect(sock string) error {
 
 				// Retry to connect to the switch if hit error
 				for i := 0; i < maxRetry; i++ {
-					conn, err = net.Dial("unix", sock)
+					// Linux: Connect to Unix Domain Socket file
+					// Windows: Connect to named pipe
+					conn, err = DialUnixOrNamedPipe(sock)
 					if err != nil {
 						log.Errorf("Failed to connect to %s: %v, retry after 1 second.", sock, err)
 						time.Sleep(retryInterval)

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -159,7 +159,7 @@ func TestMain(m *testing.M) {
 	ovsDriver2 = ovsdbDriver.NewOvsDriver("ovsbr12")
 	//wait for 2sec and see if ovs br created
 	time.Sleep(2 * time.Second)
-	go ctrler2.Connect("/var/run/openvswitch/ovsbr12.mgmt")
+	go ctrler2.Connect(fmt.Sprintf(defaultOVSDBAddressFormat, "ovsbr12"))
 
 	//wait for 10sec and see if switch connects
 	time.Sleep(8 * time.Second)
@@ -814,7 +814,7 @@ func TestReconnectOFSwitch(t *testing.T) {
 func prepareContollerAndSwitch(t *testing.T, app *OfActor, ctrl *Controller, brName string) (ovsBr *ovsdbDriver.OvsDriver) {
 	// Create ovs bridge and connect clientMode Controller to it
 	ovsBr = ovsdbDriver.NewOvsDriver(brName)
-	go ctrl.Connect(fmt.Sprintf("/var/run/openvswitch/%s.mgmt", brName))
+	go ctrl.Connect(fmt.Sprintf(defaultOVSDBAddressFormat, brName))
 
 	time.Sleep(2 * time.Second)
 	setOfTables(t, app, brName)

--- a/ofctrl/ofctrl_test_address_linux.go
+++ b/ofctrl/ofctrl_test_address_linux.go
@@ -1,0 +1,3 @@
+package ofctrl
+
+const defaultOVSDBAddressFormat = "/var/run/openvswitch/%s.mgmt"

--- a/ofctrl/ofctrl_test_address_windows.go
+++ b/ofctrl/ofctrl_test_address_windows.go
@@ -1,0 +1,3 @@
+package ofctrl
+
+const defaultOVSDBAddressFormat = `\\.\pipe\C:openvswitchvarrunopenvswitch%s.mgmt`


### PR DESCRIPTION
On windows platform, OVS replace Unix Domain Socket with named pip.
This patch supprt to use named pipe connection to OVS bridge.