### PR TITLE
Add build support for Mac OS

### DIFF
--- a/ofctrl/dial.go
+++ b/ofctrl/dial.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package ofctrl
 
 import "net"

--- a/ofctrl/ofctrl_test_address.go
+++ b/ofctrl/ofctrl_test_address.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package ofctrl
 
 const defaultOVSDBAddressFormat = "/var/run/openvswitch/%s.mgmt"


### PR DESCRIPTION
Unix socket is also used in Mac OS to connect to OVS bridge. This patch add build support for Mac OS.

Signed-off-by: Rui Cao <rcao@vmware.com>