### PR TITLE
Add support for PacketIn/PacketOut and tlv-map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )
+
+replace github.com/contiv/libOpenflow => github.com/wenyingd/libOpenflow v0.0.0-20200417045933-81b845c5c32e

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/wenyingd/libOpenflow v0.0.0-20200417045933-81b845c5c32e h1:hcsZ7SPZrH+9kCthOtJ+/beUhOrofMHV0eB01bx+GbI=
+github.com/wenyingd/libOpenflow v0.0.0-20200417045933-81b845c5c32e/go.mod h1:H/W3Y/315RzXOIWtWUcqb84c9Kct6Q6kxadaPydZmv8=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b h1:ag/x1USPSsqHud38I9BAC88qdNLDHHtQ4mlgQIZPPNA=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/ofctrl/fgraphFlow.go
+++ b/ofctrl/fgraphFlow.go
@@ -799,7 +799,9 @@ func (self *Flow) installFlowActions(flowMod *openflow13.FlowMod,
 
 		case "loadReg":
 			// Create NX load action
-			loadRegAction := flowAction.loadAct.GetActionMessage()
+			loadAct := flowAction.loadAct
+			self.Table.Switch.ResetFieldLength(loadAct.Field)
+			loadRegAction := loadAct.GetActionMessage()
 
 			// Add load action to the instruction
 			err = actInstr.AddAction(loadRegAction, true)
@@ -1430,6 +1432,8 @@ func (self *Flow) MoveRegs(srcName string, dstName string, srcRange *openflow13.
 	if err != nil {
 		return err
 	}
+	self.Table.Switch.ResetFieldLength(moveAct.SrcField)
+	self.Table.Switch.ResetFieldLength(moveAct.DstField)
 
 	action := new(FlowAction)
 	action.ActionType = "moveReg"

--- a/ofctrl/fgraphFlow.go
+++ b/ofctrl/fgraphFlow.go
@@ -17,6 +17,7 @@ package ofctrl
 // This file implements the forwarding graph API for the flow
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"github.com/contiv/libOpenflow/util"
@@ -68,11 +69,12 @@ type FlowMatch struct {
 	NxRegs        []*NXRegister        // regX or regX[m..n]
 	CtMark        uint32               // conn_track mark
 	CtMarkMask    *uint32              // Mask of conn_track mark
+	TunMetadatas  []*NXTunMetadata     // tun_metadataX or tun_metadataX[m..n]
 }
 
 // additional Actions in flow's instruction set
 type FlowAction struct {
-	actionType   string               // Type of action "setVlan", "setMetadata"
+	ActionType   string               // Type of action "setVlan", "setMetadata"
 	vlanId       uint16               // Vlan Id in case of "setVlan"
 	macAddr      net.HardwareAddr     // Mac address to set
 	ipAddr       net.IP               // IP address to be set
@@ -89,8 +91,9 @@ type FlowAction struct {
 	resubmit     *Resubmit            // resubmit packet to a specific Table and port. Resubmit could also be a NextElem.
 	// If the packet is resubmitted to multiple ports, use resubmit as a FlowAction
 	// and the NextElem should be Empty.
-	learn *FlowLearn // nxm learn action
-	notes []byte     // data to set in note action
+	learn      *FlowLearn    // nxm learn action
+	notes      []byte        // data to set in note action
+	controller *NXController // send packet to controller
 }
 
 // State of a flow entry
@@ -98,6 +101,8 @@ type Flow struct {
 	Table       *Table        // Table where this flow resides
 	Match       FlowMatch     // Fields to be matched
 	NextElem    FgraphElem    // Next fw graph element
+	HardTimeout uint16        // Timeout to remove the flow after it is installed in the switch
+	IdleTimeout uint16        // Timeout to remove the flow after its last hit
 	isInstalled bool          // Is the flow installed in the switch
 	CookieID    uint64        // Cookie ID for flowMod message
 	CookieMask  uint64        // Cookie Mask for flowMod message
@@ -124,6 +129,12 @@ type NXRegister struct {
 	ID    int                 // ID of NXM_NX_REG, value should be from 0 to 15
 	Data  uint32              // Data to cache in register
 	Range *openflow13.NXRange // Range of bits in register
+}
+
+type NXTunMetadata struct {
+	ID    int                 // ID of NXM_NX_TUN_METADATA, value should be from 0 to 7. OVS supports 64 tun_metadata, but only 0-7 is implemented in libOpenflow
+	Data  interface{}         // Data to set in the register
+	Range *openflow13.NXRange // Range of bits in the field
 }
 
 const IP_PROTO_TCP = 6
@@ -373,7 +384,92 @@ func (self *Flow) xlateMatch() openflow13.Match {
 		ofMatch.AddField(*ctMarkField)
 	}
 
+	// Handle tun_metadata match
+	if len(self.Match.TunMetadatas) > 0 {
+		for _, m := range self.Match.TunMetadatas {
+			data := getDataBytes(m.Data, m.Range)
+			var mask []byte
+			if m.Range != nil {
+				start := int(m.Range.GetOfs())
+				length := int(m.Range.GetNbits())
+				mask = getMaskBytes(start, length)
+			}
+			tmField := openflow13.NewTunMetadataField(m.ID, data, mask)
+			ofMatch.AddField(*tmField)
+		}
+	}
+
 	return *ofMatch
+}
+
+func getDataBytes(value interface{}, nxRange *openflow13.NXRange) []byte {
+	start := int(nxRange.GetOfs())
+	length := int(nxRange.GetNbits())
+	switch v := value.(type) {
+	case uint32:
+		rst := getUint32WithOfs(v, start, length)
+		data := make([]byte, 4)
+		binary.BigEndian.PutUint32(data, rst)
+		return data
+	case uint64:
+		rst := getUint64WithOfs(v, start, length)
+		data := make([]byte, 8)
+		binary.BigEndian.PutUint64(data, rst)
+		return data
+	case []byte:
+		return v
+	}
+	return nil
+}
+
+func getUint32WithOfs(data uint32, start, length int) uint32 {
+	return data << (32 - length) >> (32 - length - start)
+}
+
+func getUint64WithOfs(data uint64, start, length int) uint64 {
+	return data << (64 - length) >> (64 - length - start)
+}
+
+func getMaskBytes(start, length int) []byte {
+	end := start + length - 1
+	if end < 32 {
+		data := make([]byte, 4)
+		mask := getUint32WithOfs(^uint32(0), start, length)
+		binary.BigEndian.PutUint32(data, mask)
+		return data
+	}
+	if end < 64 {
+		data := make([]byte, 8)
+		mask := getUint64WithOfs(^uint64(0), start, length)
+		binary.BigEndian.PutUint64(data, mask)
+		return data
+	}
+	i := 0
+	bytesLength := 8 * ((end + 63) / 64)
+	data := make([]byte, bytesLength)
+	for i < bytesLength {
+		subStart := i * 64
+		subEnd := i*64 + 63
+		if start > subEnd {
+			binary.BigEndian.PutUint64(data[i:], uint64(0))
+			i += 8
+			continue
+		}
+		var rngStart, rngLength int
+		if start < subStart {
+			rngStart = 0
+		} else {
+			rngStart = start - subStart
+		}
+		if end > subEnd {
+			rngLength = 64 - rngStart
+		} else {
+			rngLength = (end - subStart) - rngStart + 1
+		}
+		data = append(data, getMaskBytes(rngStart, rngLength)...)
+		i += 8
+	}
+	return data
 }
 
 // Install all flow Actions
@@ -395,7 +491,7 @@ func (self *Flow) installFlowActions(flowMod *openflow13.FlowMod,
 	// order as it is added by the client.
 	for i := len(self.flowActions) - 1; i >= 0; i-- {
 		flowAction := self.flowActions[i]
-		switch flowAction.actionType {
+		switch flowAction.ActionType {
 		case "setVlan":
 			// Push Vlan Tag action
 			pushVlanAction := openflow13.NewActionPushVlan(0x8100)
@@ -793,9 +889,17 @@ func (self *Flow) installFlowActions(flowMod *openflow13.FlowMod,
 			}
 			addActn = true
 
-			log.Debugf("flow action: Added learn Action: %+v", noteAction)
+			log.Debugf("flow action: Added note Action: %+v", noteAction)
+		case "controller":
+			act := flowAction.controller
+			err = actInstr.AddAction(act.GetActionMessage(), true)
+			if err != nil {
+				return err
+			}
+			addActn = true
+			log.Debugf("flow action: Added controller Action: %+v", act)
 		default:
-			log.Fatalf("Unknown action type %s", flowAction.actionType)
+			log.Fatalf("Unknown action type %s", flowAction.ActionType)
 			return UnknownActionTypeError
 		}
 	}
@@ -823,6 +927,12 @@ func (self *Flow) GenerateFlowModMessage(commandType int) (flowMod *openflow13.F
 	flowMod.Cookie = self.CookieID
 	if self.CookieMask > 0 {
 		flowMod.CookieMask = self.CookieMask
+	}
+	if self.HardTimeout > 0 {
+		flowMod.HardTimeout = self.HardTimeout
+	}
+	if self.IdleTimeout > 0 {
+		flowMod.IdleTimeout = self.IdleTimeout
 	}
 	flowMod.Command = uint8(commandType)
 
@@ -868,7 +978,7 @@ func (self *Flow) GenerateFlowModMessage(commandType int) (flowMod *openflow13.F
 
 				log.Debugf("flow install: added next instr: %+v", instr)
 			}
-		case "NxOutput":
+		case "nxOutput":
 			fallthrough
 		case "group":
 			fallthrough
@@ -963,7 +1073,7 @@ func (self *Flow) Next(elem FgraphElem) error {
 // Special action on the flow to set vlan id
 func (self *Flow) SetVlan(vlanId uint16) error {
 	action := new(FlowAction)
-	action.actionType = "setVlan"
+	action.ActionType = "setVlan"
 	action.vlanId = vlanId
 
 	self.lock.Lock()
@@ -983,7 +1093,7 @@ func (self *Flow) SetVlan(vlanId uint16) error {
 // Special action on the flow to set vlan id
 func (self *Flow) PopVlan() error {
 	action := new(FlowAction)
-	action.actionType = "popVlan"
+	action.ActionType = "popVlan"
 
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1002,7 +1112,7 @@ func (self *Flow) PopVlan() error {
 // Special action on the flow to set mac dest addr
 func (self *Flow) SetMacDa(macDa net.HardwareAddr) error {
 	action := new(FlowAction)
-	action.actionType = "setMacDa"
+	action.ActionType = "setMacDa"
 	action.macAddr = macDa
 
 	self.lock.Lock()
@@ -1022,7 +1132,7 @@ func (self *Flow) SetMacDa(macDa net.HardwareAddr) error {
 // Special action on the flow to set mac source addr
 func (self *Flow) SetMacSa(macSa net.HardwareAddr) error {
 	action := new(FlowAction)
-	action.actionType = "setMacSa"
+	action.ActionType = "setMacSa"
 	action.macAddr = macSa
 
 	self.lock.Lock()
@@ -1044,13 +1154,13 @@ func (self *Flow) SetIPField(ip net.IP, field string) error {
 	action := new(FlowAction)
 	action.ipAddr = ip
 	if field == "Src" {
-		action.actionType = "setIPSa"
+		action.ActionType = "setIPSa"
 	} else if field == "Dst" {
-		action.actionType = "setIPDa"
+		action.ActionType = "setIPDa"
 	} else if field == "TunSrc" {
-		action.actionType = "setTunSa"
+		action.ActionType = "setTunSa"
 	} else if field == "TunDst" {
-		action.actionType = "setTunDa"
+		action.ActionType = "setTunDa"
 	} else {
 		return errors.New("field not supported")
 	}
@@ -1073,7 +1183,7 @@ func (self *Flow) SetIPField(ip net.IP, field string) error {
 func (self *Flow) SetARPSpa(ip net.IP) error {
 	action := new(FlowAction)
 	action.ipAddr = ip
-	action.actionType = "setARPSpa"
+	action.ActionType = "setARPSpa"
 
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1093,7 +1203,7 @@ func (self *Flow) SetARPSpa(ip net.IP) error {
 func (self *Flow) SetARPTpa(ip net.IP) error {
 	action := new(FlowAction)
 	action.ipAddr = ip
-	action.actionType = "setARPTpa"
+	action.ActionType = "setARPTpa"
 
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1116,22 +1226,22 @@ func (self *Flow) SetL4Field(port uint16, field string) error {
 
 	switch field {
 	case "TCPSrc":
-		action.actionType = "setTCPSrc"
+		action.ActionType = "setTCPSrc"
 		break
 	case "TCPDst":
-		action.actionType = "setTCPDst"
+		action.ActionType = "setTCPDst"
 		break
 	case "UDPSrc":
-		action.actionType = "setUDPSrc"
+		action.ActionType = "setUDPSrc"
 		break
 	case "UDPDst":
-		action.actionType = "setUDPDst"
+		action.ActionType = "setUDPDst"
 		break
 	case "SCTPSrc":
-		action.actionType = "setSCTPSrc"
+		action.ActionType = "setSCTPSrc"
 		break
 	case "SCTPDst":
-		action.actionType = "setSCTPDst"
+		action.ActionType = "setSCTPDst"
 		break
 	default:
 		return errors.New("field not supported")
@@ -1154,7 +1264,7 @@ func (self *Flow) SetL4Field(port uint16, field string) error {
 // Special actions on the flow to set metadata
 func (self *Flow) SetMetadata(metadata, metadataMask uint64) error {
 	action := new(FlowAction)
-	action.actionType = "setMetadata"
+	action.ActionType = "setMetadata"
 	action.metadata = metadata
 	action.metadataMask = metadataMask
 
@@ -1175,7 +1285,7 @@ func (self *Flow) SetMetadata(metadata, metadataMask uint64) error {
 // Special actions on the flow to set vlan id
 func (self *Flow) SetTunnelId(tunnelId uint64) error {
 	action := new(FlowAction)
-	action.actionType = "setTunnelId"
+	action.ActionType = "setTunnelId"
 	action.tunnelId = tunnelId
 
 	self.lock.Lock()
@@ -1195,7 +1305,7 @@ func (self *Flow) SetTunnelId(tunnelId uint64) error {
 // Special actions on the flow to set dscp field
 func (self *Flow) SetDscp(dscp uint8) error {
 	action := new(FlowAction)
-	action.actionType = "setDscp"
+	action.ActionType = "setDscp"
 	action.dscp = dscp
 
 	self.lock.Lock()
@@ -1219,7 +1329,7 @@ func (self *Flow) UnsetDscp() error {
 
 	// Delete to the action from db
 	for idx, act := range self.flowActions {
-		if act.actionType == "setDscp" {
+		if act.ActionType == "setDscp" {
 			self.flowActions = append(self.flowActions[:idx], self.flowActions[idx+1:]...)
 		}
 	}
@@ -1234,7 +1344,7 @@ func (self *Flow) UnsetDscp() error {
 
 func (self *Flow) SetARPOper(arpOp uint16) error {
 	action := new(FlowAction)
-	action.actionType = "setARPOper"
+	action.ActionType = "setARPOper"
 	action.arpOper = arpOp
 
 	self.lock.Lock()
@@ -1254,7 +1364,7 @@ func (self *Flow) SetARPOper(arpOp uint16) error {
 // Special action on the flow to set ARP source host addr
 func (self *Flow) SetARPSha(arpSha net.HardwareAddr) error {
 	action := new(FlowAction)
-	action.actionType = "setARPSha"
+	action.ActionType = "setARPSha"
 	action.macAddr = arpSha
 
 	self.lock.Lock()
@@ -1274,7 +1384,7 @@ func (self *Flow) SetARPSha(arpSha net.HardwareAddr) error {
 // Special action on the flow to set ARP target host addr
 func (self *Flow) SetARPTha(arpTha net.HardwareAddr) error {
 	action := new(FlowAction)
-	action.actionType = "setARPTha"
+	action.ActionType = "setARPTha"
 	action.macAddr = arpTha
 
 	self.lock.Lock()
@@ -1299,7 +1409,7 @@ func (self *Flow) LoadReg(fieldName string, data uint64, dataRange *openflow13.N
 	}
 
 	action := new(FlowAction)
-	action.actionType = "loadReg"
+	action.ActionType = "loadReg"
 	action.loadAct = loadAct
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1322,7 +1432,7 @@ func (self *Flow) MoveRegs(srcName string, dstName string, srcRange *openflow13.
 	}
 
 	action := new(FlowAction)
-	action.actionType = "moveReg"
+	action.ActionType = "moveReg"
 	action.moveAct = moveAct
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1339,7 +1449,7 @@ func (self *Flow) MoveRegs(srcName string, dstName string, srcRange *openflow13.
 
 func (self *Flow) Resubmit(ofPort uint16, tableID uint8) error {
 	action := new(FlowAction)
-	action.actionType = "resubmit"
+	action.ActionType = "resubmit"
 	action.resubmit = NewResubmit(&ofPort, &tableID)
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1364,7 +1474,7 @@ func (self *Flow) ConnTrack(commit bool, force bool, tableID *uint8, zoneID *uin
 		actions: execActions,
 	}
 	action := new(FlowAction)
-	action.actionType = "ct"
+	action.ActionType = "ct"
 	action.connTrack = connTrack
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1392,7 +1502,7 @@ func (self *Flow) AddConjunction(conjID uint32, clause uint8, nClause uint8) err
 	}
 
 	action := new(FlowAction)
-	action.actionType = "conjunction"
+	action.ActionType = "conjunction"
 	action.conjunction = conjunction
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1415,7 +1525,7 @@ func (self *Flow) DelConjunction(conjID uint32) error {
 
 	// Remove conjunction from the action db
 	for i, act := range self.flowActions {
-		if act.actionType == "conjunction" {
+		if act.ActionType == "conjunction" {
 			conjuncAct := act.conjunction
 			if conjID == conjuncAct.ID {
 				self.flowActions = append(self.flowActions[:i], self.flowActions[i+1:]...)
@@ -1443,7 +1553,7 @@ func (self *Flow) DelConjunction(conjID uint32) error {
 // Special Actions to the flow to dec TTL
 func (self *Flow) DecTTL() error {
 	action := new(FlowAction)
-	action.actionType = "decTTL"
+	action.ActionType = "decTTL"
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
@@ -1460,7 +1570,7 @@ func (self *Flow) DecTTL() error {
 // Special Actions to the flow to learn from the current packet and generate a new flow entry.
 func (self *Flow) Learn(learn *FlowLearn) error {
 	action := new(FlowAction)
-	action.actionType = "learn"
+	action.ActionType = "learn"
 	action.learn = learn
 	self.lock.Lock()
 	defer self.lock.Unlock()
@@ -1477,8 +1587,28 @@ func (self *Flow) Learn(learn *FlowLearn) error {
 
 func (self *Flow) Note(data []byte) error {
 	action := new(FlowAction)
-	action.actionType = "note"
+	action.ActionType = "note"
 	action.notes = data
+	self.lock.Lock()
+	defer self.lock.Unlock()
+
+	// Add to the action db
+	self.flowActions = append(self.flowActions, action)
+	// If the flow entry was already installed, re-install it
+	if self.isInstalled {
+		return self.install()
+	}
+
+	return nil
+}
+
+func (self *Flow) Controller(reason uint8) error {
+	action := new(FlowAction)
+	action.controller = &NXController{
+		ControllerID: self.Table.Switch.ctrlID,
+		Reason:       reason,
+	}
+	action.ActionType = "controller"
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
@@ -1543,7 +1673,10 @@ func (self *Flow) IsRealized() bool {
 // MonitorRealizeStatus sends MultipartRequest to get current flow status, it is calling if needs to check
 // flow's realized status
 func (self *Flow) MonitorRealizeStatus() {
-	stats := self.Table.Switch.DumpFlowStats(self.CookieID, self.CookieMask, &self.Match, &self.Table.TableId)
+	stats, err := self.Table.Switch.DumpFlowStats(self.CookieID, self.CookieMask, &self.Match, &self.Table.TableId)
+	if err != nil {
+		self.realized = false
+	}
 	if stats != nil {
 		self.realized = true
 	}
@@ -1593,6 +1726,14 @@ func (self *Flow) ClearActions() {
 	self.clearActions = true
 }
 
+func (self *Flow) Drop() {
+	self.appliedActions = nil
+	self.metadata = nil
+	self.writeActions = nil
+	self.clearActions = false
+	self.gotoTable = nil
+}
+
 func (self *Flow) generateFlowMessage(commandType int) (flowMod *openflow13.FlowMod, err error) {
 	flowMod = openflow13.NewFlowMod()
 	flowMod.TableId = self.Table.TableId
@@ -1605,6 +1746,12 @@ func (self *Flow) generateFlowMessage(commandType int) (flowMod *openflow13.Flow
 	flowMod.Cookie = self.CookieID
 	if self.CookieMask > 0 {
 		flowMod.CookieMask = self.CookieMask
+	}
+	if self.HardTimeout > 0 {
+		flowMod.HardTimeout = self.HardTimeout
+	}
+	if self.IdleTimeout > 0 {
+		flowMod.IdleTimeout = self.IdleTimeout
 	}
 	flowMod.Command = uint8(commandType)
 

--- a/ofctrl/fgraphGroup.go
+++ b/ofctrl/fgraphGroup.go
@@ -39,6 +39,10 @@ func (self *Group) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionGroup(self.ID)
 }
 
+func (self *Group) GetActionType() string {
+	return ActTypeGroup
+}
+
 func (self *Group) GetFlowInstr() openflow13.Instruction {
 	groupInstr := openflow13.NewInstrApplyActions()
 	groupAct := self.GetActionMessage()

--- a/ofctrl/fgraphNXOutput.go
+++ b/ofctrl/fgraphNXOutput.go
@@ -11,7 +11,7 @@ type NXOutput struct {
 
 // Fgraph element type for the NXOutput
 func (self *NXOutput) Type() string {
-	return "NxOutput"
+	return "nxOutput"
 }
 
 // instruction set for NXOutput element
@@ -28,6 +28,10 @@ func (self *NXOutput) GetActionMessage() openflow13.Action {
 	targetField := self.field
 	// Create NX output Register action
 	return openflow13.NewOutputFromField(targetField, ofsNbits)
+}
+
+func (self *NXOutput) GetActionType() string {
+	return ActTypeNXOutput
 }
 
 func NewNXOutput(name string, start int, end int) (*NXOutput, error) {

--- a/ofctrl/fgraphOutput.go
+++ b/ofctrl/fgraphOutput.go
@@ -76,6 +76,10 @@ func (self *Output) GetActionMessage() openflow13.Action {
 	return nil
 }
 
+func (self *Output) GetActionType() string {
+	return ActTypeOutput
+}
+
 func NewOutputInPort() *Output {
 	return &Output{outputType: "inPort", portNo: openflow13.P_IN_PORT}
 }
@@ -86,4 +90,8 @@ func NewOutputNormal() *Output {
 
 func NewOutputPort(portNo uint32) *Output {
 	return &Output{outputType: "port", portNo: portNo}
+}
+
+func NewOutputController() *Output {
+	return &Output{outputType: "toController"}
 }

--- a/ofctrl/fgraphResubmit.go
+++ b/ofctrl/fgraphResubmit.go
@@ -27,6 +27,10 @@ func (self *Resubmit) GetActionMessage() openflow13.Action {
 	return openflow13.NewNXActionResubmitTableAction(self.ofport, self.nextTable)
 }
 
+func (self *Resubmit) GetActionType() string {
+	return ActTypeNXResubmit
+}
+
 func NewResubmit(inPort *uint16, table *uint8) *Resubmit {
 	resubmit := new(Resubmit)
 	if inPort == nil {

--- a/ofctrl/learnAction.go
+++ b/ofctrl/learnAction.go
@@ -100,6 +100,10 @@ func (l *FlowLearn) GetActionMessage() openflow13.Action {
 	return learnAction
 }
 
+func (l *FlowLearn) GetActionType() string {
+	return ActTypeNXLearn
+}
+
 func (l *FlowLearn) DeleteLearnedFlowsAfterDeletion() {
 	l.flags |= openflow13.NX_LEARN_F_DELETE_LEARNED
 }

--- a/ofctrl/ofAction.go
+++ b/ofctrl/ofAction.go
@@ -8,8 +8,47 @@ import (
 	"github.com/contiv/libOpenflow/openflow13"
 )
 
+const (
+	ActTypeSetVlan        = "setVlan"
+	ActTypePopVlan        = "popVlan"
+	ActTypeSetDstMac      = "setMacDa"
+	ActTypeSetSrcMac      = "setMacSa"
+	ActTypeSetTunnelID    = "setTunnelId"
+	ActTypeMetatdata      = "setMetadata"
+	ActTypeSetSrcIP       = "setIPSa"
+	ActTypeSetDstIP       = "setIPDa"
+	ActTypeSetTunnelSrcIP = "setTunSa"
+	ActTypeSetTunnelDstIP = "setTunDa"
+	ActTypeSetDSCP        = "setDscp"
+	ActTypeSetARPOper     = "setARPOper"
+	ActTypeSetARPSHA      = "setARPSha"
+	ActTypeSetARPTHA      = "setARPTha"
+	ActTypeSetARPSPA      = "setARPSpa"
+	ActTypeSetARPTPA      = "setARPTpa"
+	ActTypeSetTCPsPort    = "setTCPSrc"
+	ActTypeSetTCPdPort    = "setTCPDst"
+	ActTypeSetTCPFlags    = "setTCPFlags"
+	ActTypeSetUDPsPort    = "setUDPSrc"
+	ActTypeSetUDPdPort    = "setUDPDst"
+	ActTypeSetSCTPsPort   = "setSCTPSrc"
+	ActTypeSetSCTPdPort   = "setSCTPDst"
+	ActTypeNXLoad         = "loadReg"
+	ActTypeNXMove         = "moveReg"
+	ActTypeNXCT           = "ct"
+	ActTypeNXConjunction  = "conjunction"
+	ActTypeDecTTL         = "decTTL"
+	ActTypeNXResubmit     = "resubmit"
+	ActTypeGroup          = "group"
+	ActTypeNXLearn        = "learn"
+	ActTypeNXNote         = "note"
+	ActTypeController     = "controller"
+	ActTypeOutput         = "output"
+	ActTypeNXOutput       = "nxOutput"
+)
+
 type OFAction interface {
 	GetActionMessage() openflow13.Action
+	GetActionType() string
 }
 
 type SetVLANAction struct {
@@ -21,11 +60,19 @@ func (a *SetVLANAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetVLANAction) GetActionType() string {
+	return ActTypeSetVlan
+}
+
 type PopVLANAction struct {
 }
 
 func (a *PopVLANAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionPopVlan()
+}
+
+func (a *PopVLANAction) GetActionType() string {
+	return ActTypePopVlan
 }
 
 type SetSrcMACAction struct {
@@ -37,6 +84,10 @@ func (a *SetSrcMACAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetSrcMACAction) GetActionType() string {
+	return ActTypeSetSrcMac
+}
+
 type SetDstMACAction struct {
 	MAC net.HardwareAddr
 }
@@ -44,6 +95,10 @@ type SetDstMACAction struct {
 func (a *SetDstMACAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewEthDstField(a.MAC, nil)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetDstMACAction) GetActionType() string {
+	return ActTypeSetDstMac
 }
 
 type SetTunnelIDAction struct {
@@ -55,6 +110,10 @@ func (a *SetTunnelIDAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetTunnelIDAction) GetActionType() string {
+	return ActTypeSetTunnelID
+}
+
 type SetTunnelDstAction struct {
 	IP net.IP
 }
@@ -62,6 +121,10 @@ type SetTunnelDstAction struct {
 func (a *SetTunnelDstAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewTunnelIpv4DstField(a.IP, nil)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetTunnelDstAction) GetActionType() string {
+	return ActTypeSetTunnelDstIP
 }
 
 type SetTunnelSrcAction struct {
@@ -73,6 +136,10 @@ func (a *SetTunnelSrcAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetTunnelSrcAction) GetActionType() string {
+	return ActTypeSetTunnelSrcIP
+}
+
 type SetDstIPAction struct {
 	IP net.IP
 }
@@ -80,6 +147,10 @@ type SetDstIPAction struct {
 func (a *SetDstIPAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewIpv4DstField(a.IP, nil)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetDstIPAction) GetActionType() string {
+	return ActTypeSetDstIP
 }
 
 type SetSrcIPAction struct {
@@ -91,6 +162,10 @@ func (a *SetSrcIPAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetSrcIPAction) GetActionType() string {
+	return ActTypeSetSrcIP
+}
+
 type SetDSCPAction struct {
 	Value uint8
 }
@@ -98,6 +173,10 @@ type SetDSCPAction struct {
 func (a *SetDSCPAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewIpDscpField(a.Value)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetDSCPAction) GetActionType() string {
+	return ActTypeSetDSCP
 }
 
 type SetARPOpAction struct {
@@ -109,6 +188,10 @@ func (a *SetARPOpAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetARPOpAction) GetActionType() string {
+	return ActTypeSetARPOper
+}
+
 type SetARPShaAction struct {
 	MAC net.HardwareAddr
 }
@@ -116,6 +199,10 @@ type SetARPShaAction struct {
 func (a *SetARPShaAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewArpShaField(a.MAC)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetARPShaAction) GetActionType() string {
+	return ActTypeSetARPSHA
 }
 
 type SetARPThaAction struct {
@@ -127,6 +214,10 @@ func (a *SetARPThaAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetARPThaAction) GetActionType() string {
+	return ActTypeSetARPTHA
+}
+
 type SetARPSpaAction struct {
 	IP net.IP
 }
@@ -134,6 +225,10 @@ type SetARPSpaAction struct {
 func (a *SetARPSpaAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewArpSpaField(a.IP)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetARPSpaAction) GetActionType() string {
+	return ActTypeSetARPSPA
 }
 
 type SetARPTpaAction struct {
@@ -145,6 +240,10 @@ func (a *SetARPTpaAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetARPTpaAction) GetActionType() string {
+	return ActTypeSetARPTPA
+}
+
 type SetTCPSrcPortAction struct {
 	Port uint16
 }
@@ -154,6 +253,10 @@ func (a *SetTCPSrcPortAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetTCPSrcPortAction) GetActionType() string {
+	return ActTypeSetTCPsPort
+}
+
 type SetTCPDstPortAction struct {
 	Port uint16
 }
@@ -161,6 +264,10 @@ type SetTCPDstPortAction struct {
 func (a *SetTCPDstPortAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewTcpDstField(a.Port)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetTCPDstPortAction) GetActionType() string {
+	return ActTypeSetTCPdPort
 }
 
 type SetTCPFlagsAction struct {
@@ -173,6 +280,10 @@ func (a *SetTCPFlagsAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetTCPFlagsAction) GetActionType() string {
+	return ActTypeSetTCPFlags
+}
+
 type SetUDPSrcPortAction struct {
 	Port uint16
 }
@@ -180,6 +291,10 @@ type SetUDPSrcPortAction struct {
 func (a *SetUDPSrcPortAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewUdpSrcField(a.Port)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetUDPSrcPortAction) GetActionType() string {
+	return ActTypeSetUDPsPort
 }
 
 type SetUDPDstPortAction struct {
@@ -191,6 +306,10 @@ func (a *SetUDPDstPortAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetUDPDstPortAction) GetActionType() string {
+	return ActTypeSetUDPdPort
+}
+
 type SetSCTPSrcAction struct {
 	Port uint16
 }
@@ -198,6 +317,10 @@ type SetSCTPSrcAction struct {
 func (a *SetSCTPSrcAction) GetActionMessage() openflow13.Action {
 	field := openflow13.NewSctpSrcField(a.Port)
 	return openflow13.NewActionSetField(*field)
+}
+
+func (a *SetSCTPSrcAction) GetActionType() string {
+	return ActTypeSetSCTPsPort
 }
 
 type SetSCTPDstAction struct {
@@ -209,6 +332,10 @@ func (a *SetSCTPDstAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionSetField(*field)
 }
 
+func (a *SetSCTPDstAction) GetActionType() string {
+	return ActTypeSetSCTPdPort
+}
+
 type NXLoadAction struct {
 	Field *openflow13.MatchField
 	Value uint64
@@ -218,6 +345,10 @@ type NXLoadAction struct {
 func (a *NXLoadAction) GetActionMessage() openflow13.Action {
 	ofsNbits := a.Range.ToOfsBits()
 	return openflow13.NewNXActionRegLoad(ofsNbits, a.Field, a.Value)
+}
+
+func (a *NXLoadAction) GetActionType() string {
+	return ActTypeNXLoad
 }
 
 func NewNXLoadAction(fieldName string, data uint64, dataRange *openflow13.NXRange) (*NXLoadAction, error) {
@@ -242,6 +373,10 @@ type NXMoveAction struct {
 
 func (a *NXMoveAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewNXActionRegMove(a.MoveNbits, a.SrcStart, a.DstStart, a.SrcField, a.DstField)
+}
+
+func (a *NXMoveAction) GetActionType() string {
+	return ActTypeNXMove
 }
 
 func NewNXMoveAction(srcName string, dstName string, srcRange *openflow13.NXRange, dstRange *openflow13.NXRange) (*NXMoveAction, error) {
@@ -297,6 +432,10 @@ func (a *NXConnTrackAction) GetActionMessage() openflow13.Action {
 	return ctAction
 }
 
+func (a *NXConnTrackAction) GetActionType() string {
+	return ActTypeNXCT
+}
+
 func NewNXConnTrackAction(commit bool, force bool, table *uint8, zone *uint16, actions ...openflow13.Action) *NXConnTrackAction {
 	return &NXConnTrackAction{
 		commit:  commit,
@@ -315,6 +454,10 @@ type NXConjunctionAction struct {
 
 func (a *NXConjunctionAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewNXActionConjunction(a.Clause, a.NClause, a.ID)
+}
+
+func (a *NXConjunctionAction) GetActionType() string {
+	return ActTypeNXConjunction
 }
 
 func NewNXConjunctionAction(conjID uint32, clause uint8, nClause uint8) (*NXConjunctionAction, error) {
@@ -340,6 +483,10 @@ func (a *DecTTLAction) GetActionMessage() openflow13.Action {
 	return openflow13.NewActionDecNwTtl()
 }
 
+func (a *DecTTLAction) GetActionType() string {
+	return ActTypeDecTTL
+}
+
 type NXNoteAction struct {
 	Notes []byte
 }
@@ -348,4 +495,24 @@ func (a *NXNoteAction) GetActionMessage() openflow13.Action {
 	noteAction := openflow13.NewNXActionNote()
 	noteAction.Note = a.Notes
 	return noteAction
+}
+
+func (a *NXNoteAction) GetActionType() string {
+	return ActTypeNXNote
+}
+
+type NXController struct {
+	ControllerID uint16
+	Reason       uint8
+}
+
+func (a *NXController) GetActionMessage() openflow13.Action {
+	action := openflow13.NewNXActionController(a.ControllerID)
+	action.MaxLen = 128
+	action.Reason = a.Reason
+	return action
+}
+
+func (a *NXController) GetActionType() string {
+	return ActTypeController
 }

--- a/ofctrl/ofMatchFields.go
+++ b/ofctrl/ofMatchFields.go
@@ -1,0 +1,775 @@
+package ofctrl
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/contiv/libOpenflow/openflow13"
+	"github.com/contiv/libOpenflow/util"
+	"net"
+)
+
+type Uint32WithMask struct {
+	Value uint32
+	Mask  uint32
+}
+
+type Uint64WithMask struct {
+	Value uint64
+	Mask  uint64
+}
+
+type DataWithMask struct {
+	Value []byte
+	Mask  []byte
+}
+
+type CTStatesChecker Uint32WithMask
+
+type Matchers struct {
+	matches []*MatchField
+}
+
+func (m *Matchers) GetMatch(class uint16, field uint8) *MatchField {
+	for _, m := range m.matches {
+		if m.Class == class && m.Field == field {
+			return m
+		}
+	}
+	return nil
+}
+
+func (m *Matchers) GetMatchByName(name string) *MatchField {
+	mfHeader, err := openflow13.FindFieldHeaderByName(name, false)
+	if err != nil {
+		return nil
+	}
+	return m.GetMatch(mfHeader.Class, mfHeader.Field)
+}
+
+func (s *CTStatesChecker) IsNew() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_NEW_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnNew() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_NEW_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+func (s *CTStatesChecker) IsRpl() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_RPL_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnRpl() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_RPL_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+func (s *CTStatesChecker) IsRel() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_REL_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnRel() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_REL_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+func (s *CTStatesChecker) IsEst() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_EST_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnEst() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_EST_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+func (s *CTStatesChecker) IsTrk() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_TRK_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnTrk() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_TRK_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+func (s *CTStatesChecker) IsInv() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_INV_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnInv() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_INV_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+func (s *CTStatesChecker) IsSNAT() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_SNAT_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnSNAT() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_SNAT_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+func (s *CTStatesChecker) IsDNAT() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_SNAT_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData != 0)
+}
+
+func (s *CTStatesChecker) IsUnDNAT() bool {
+	checkData := uint32(1 << openflow13.NX_CT_STATE_DNAT_OFS)
+	return (s.Mask&checkData != 0) && (s.Value&checkData == 0)
+}
+
+type MatchField struct {
+	*openflow13.MatchField
+	nickName string
+	name     string
+}
+
+func (m *MatchField) GetNickName() string {
+	return m.nickName
+}
+
+func (m *MatchField) GetName() string {
+	return m.name
+}
+
+func (m *MatchField) GetValue() interface{} {
+	switch v := m.Value.(type) {
+	case *openflow13.InPortField:
+		return v.InPort
+	case *openflow13.MetadataField:
+		value := v.Metadata
+		if !m.HasMask {
+			return value
+		}
+		maskData, _ := m.Mask.(*openflow13.MetadataField)
+		return Uint64WithMask{
+			Value: value,
+			Mask:  maskData.Metadata,
+		}
+	case *openflow13.EthDstField:
+		return v.EthDst
+	case *openflow13.EthSrcField:
+		return v.EthSrc
+	case *openflow13.EthTypeField:
+		return v.EthType
+	case *openflow13.VlanIdField:
+		return v.VlanId
+	case *openflow13.IpDscpField:
+		value, _ := getUint8(m.Value)
+		return value
+	case *openflow13.IpProtoField:
+		value, _ := getUint8(m.Value)
+		return value
+	case *openflow13.Ipv4SrcField:
+		value := v.Ipv4Src
+		if !m.HasMask {
+			return value
+		}
+		maskData, _ := m.Mask.(*openflow13.Ipv4SrcField)
+		mask := maskData.Ipv4Src
+		return net.IPNet{
+			IP:   value,
+			Mask: net.IPv4Mask(mask[0], mask[1], mask[2], mask[3]),
+		}
+	case *openflow13.Ipv4DstField:
+		value := v.Ipv4Dst
+		if !m.HasMask {
+			return value
+		}
+		maskData, _ := m.Mask.(*openflow13.Ipv4DstField)
+		mask := maskData.Ipv4Dst
+		return net.IPNet{
+			IP:   value,
+			Mask: net.IPv4Mask(mask[0], mask[1], mask[2], mask[3]),
+		}
+	case *openflow13.PortField:
+		value, _ := getUint16(m.Value)
+		return value
+	case *openflow13.ArpOperField:
+		return v.ArpOper
+	case *openflow13.ArpXHaField:
+		return v.ArpHa
+	case *openflow13.ArpXPaField:
+		return v.ArpPa
+	case *openflow13.Ipv6SrcField:
+		return v.Ipv6Src
+	case *openflow13.Ipv6DstField:
+		return v.Ipv6Dst
+	case *openflow13.MplsLabelField:
+		return v.MplsLabel
+	case *openflow13.MplsBosField:
+		return v.MplsBos
+	case *openflow13.TunnelIdField:
+		return v.TunnelId
+	case *openflow13.TcpFlagsField:
+		return v.TcpFlags
+	case *openflow13.TunnelIpv4SrcField:
+		return v.TunnelIpv4Src
+	case *openflow13.TunnelIpv4DstField:
+		return v.TunnelIpv4Dst
+	case *openflow13.Uint16Message:
+		return v.Data
+	case *openflow13.Uint32Message:
+		switch m.Field {
+		case openflow13.NXM_NX_CT_STATE:
+			fieldValue, _ := getCTState(m.MatchField)
+			return fieldValue
+		case openflow13.NXM_NX_REG0:
+			fallthrough
+		case openflow13.NXM_NX_REG1:
+			fallthrough
+		case openflow13.NXM_NX_REG2:
+			fallthrough
+		case openflow13.NXM_NX_REG3:
+			fallthrough
+		case openflow13.NXM_NX_REG4:
+			fallthrough
+		case openflow13.NXM_NX_REG5:
+			fallthrough
+		case openflow13.NXM_NX_REG6:
+			fallthrough
+		case openflow13.NXM_NX_REG7:
+			fallthrough
+		case openflow13.NXM_NX_REG8:
+			fallthrough
+		case openflow13.NXM_NX_REG9:
+			fallthrough
+		case openflow13.NXM_NX_REG10:
+			fallthrough
+		case openflow13.NXM_NX_REG11:
+			fallthrough
+		case openflow13.NXM_NX_REG12:
+			fallthrough
+		case openflow13.NXM_NX_REG13:
+			fallthrough
+		case openflow13.NXM_NX_REG14:
+			fallthrough
+		case openflow13.NXM_NX_REG15:
+			reg, _ := getNXReg(m.MatchField)
+			return reg
+		}
+		value := v.Data
+		if !m.HasMask {
+			return value
+		}
+		maskData := m.Mask.(*openflow13.Uint32Message)
+		return &Uint32WithMask{
+			Value: value,
+			Mask:  maskData.Data,
+		}
+	case *openflow13.ByteArrayField:
+		value := v.Data
+		if !m.HasMask {
+			return value
+		}
+		mask, _ := m.Mask.MarshalBinary()
+		return &DataWithMask{
+			Value: value,
+			Mask:  mask,
+		}
+	}
+	return nil
+}
+
+func NewMatchField(mf *openflow13.MatchField) *MatchField {
+	m := &MatchField{
+		MatchField: mf,
+	}
+	m.name, m.nickName = getFieldNames(mf)
+	return m
+}
+
+func getFieldNames(mf *openflow13.MatchField) (string, string) {
+	var fieldName string
+	var nickName string
+	switch mf.Class {
+	case openflow13.OXM_CLASS_NXM_0:
+		switch mf.Field {
+		case openflow13.NXM_OF_IN_PORT:
+			fieldName = "NXM_OF_IN_PORT"
+			nickName = "in_port"
+		case openflow13.NXM_OF_ETH_DST:
+			fieldName = "NXM_OF_ETH_DST"
+			nickName = "dl_src"
+		case openflow13.NXM_OF_ETH_SRC:
+			fieldName = "NXM_OF_ETH_SRC"
+			nickName = "dl_dst"
+		case openflow13.NXM_OF_ETH_TYPE:
+			fieldName = "NXM_OF_ETH_TYPE"
+			nickName = "eth_type"
+		case openflow13.NXM_OF_VLAN_TCI:
+			fieldName = "NXM_OF_VLAN_TCI"
+			nickName = "vlan_tci"
+		case openflow13.NXM_OF_IP_TOS:
+			fieldName = "NXM_OF_IP_TOS"
+			nickName = "nw_tos"
+		case openflow13.NXM_OF_IP_PROTO:
+			fieldName = "NXM_OF_IP_PROTO"
+			nickName = "ip_proto"
+		case openflow13.NXM_OF_IP_SRC:
+			fieldName = "NXM_OF_IP_SRC"
+			nickName = "nw_src"
+		case openflow13.NXM_OF_IP_DST:
+			fieldName = "NXM_OF_IP_DST"
+			nickName = "nw_dst"
+		case openflow13.NXM_OF_TCP_SRC:
+			fieldName = "NXM_OF_TCP_SRC"
+			nickName = "tp_src"
+		case openflow13.NXM_OF_TCP_DST:
+			fieldName = "NXM_OF_TCP_DST"
+			nickName = "tp_dst"
+		case openflow13.NXM_OF_UDP_SRC:
+			fieldName = "NXM_OF_UDP_SRC"
+			nickName = "tp_src"
+		case openflow13.NXM_OF_UDP_DST:
+			fieldName = "NXM_OF_UDP_DST"
+			nickName = "tp_dst"
+		case openflow13.NXM_OF_ICMP_TYPE:
+			fieldName = "NXM_OF_ICMP_TYPE"
+			nickName = "icmp_type"
+		case openflow13.NXM_OF_ICMP_CODE:
+			fieldName = "NXM_OF_ICMP_CODE"
+			nickName = "icmp_code"
+		case openflow13.NXM_OF_ARP_OP:
+			fieldName = "NXM_OF_ARP_OP"
+			nickName = "arp_op"
+		case openflow13.NXM_OF_ARP_SPA:
+			fieldName = "NXM_OF_ARP_SPA"
+			nickName = "arp_spa"
+		case openflow13.NXM_OF_ARP_TPA:
+			fieldName = "NXM_OF_ARP_TPA"
+			nickName = "arp_tpa"
+		}
+	case openflow13.OXM_CLASS_NXM_1:
+		switch mf.Field {
+		case openflow13.NXM_NX_REG0:
+			fallthrough
+		case openflow13.NXM_NX_REG1:
+			fallthrough
+		case openflow13.NXM_NX_REG2:
+			fallthrough
+		case openflow13.NXM_NX_REG3:
+			fallthrough
+		case openflow13.NXM_NX_REG4:
+			fallthrough
+		case openflow13.NXM_NX_REG5:
+			fallthrough
+		case openflow13.NXM_NX_REG6:
+			fallthrough
+		case openflow13.NXM_NX_REG7:
+			fallthrough
+		case openflow13.NXM_NX_REG8:
+			fallthrough
+		case openflow13.NXM_NX_REG9:
+			fallthrough
+		case openflow13.NXM_NX_REG10:
+			fallthrough
+		case openflow13.NXM_NX_REG11:
+			fallthrough
+		case openflow13.NXM_NX_REG12:
+			fallthrough
+		case openflow13.NXM_NX_REG13:
+			fallthrough
+		case openflow13.NXM_NX_REG14:
+			fallthrough
+		case openflow13.NXM_NX_REG15:
+			fieldName = fmt.Sprintf("NXM_NX_REG%d", mf.Field)
+			nickName = fmt.Sprintf("reg%d", mf.Field)
+		case openflow13.NXM_NX_TUN_ID:
+			fieldName = "NXM_NX_TUN_ID"
+			nickName = "tunnel_id"
+		case openflow13.NXM_NX_ARP_SHA:
+			fieldName = "NXM_NX_ARP_SHA"
+			nickName = "arp_sha"
+		case openflow13.NXM_NX_ARP_THA:
+			fieldName = "NXM_NX_ARP_THA"
+			nickName = "arp_tha"
+		case openflow13.NXM_NX_IPV6_SRC:
+			fieldName = "NXM_NX_IPV6_SRC"
+			nickName = "ipv6_src"
+		case openflow13.NXM_NX_IPV6_DST:
+			fieldName = "NXM_NX_IPV6_DST"
+			nickName = "ipv6_dst"
+		case openflow13.NXM_NX_ICMPV6_TYPE:
+			fieldName = "NXM_NX_ICMPV6_TYPE"
+			nickName = "icmpv6_type"
+		case openflow13.NXM_NX_ICMPV6_CODE:
+			fieldName = "NXM_NX_ICMPV6_CODE"
+			nickName = "icmpv6_code"
+		case openflow13.NXM_NX_ND_TARGET:
+			fieldName = "NXM_NX_ND_TARGET"
+			nickName = "nd_target"
+		case openflow13.NXM_NX_ND_SLL:
+			fieldName = "NXM_NX_ND_SLL"
+			nickName = "nd_sll"
+		case openflow13.NXM_NX_ND_TLL:
+			fieldName = "NXM_NX_ND_TLL"
+			nickName = "nd_tll"
+		case openflow13.NXM_NX_IP_FRAG:
+			fieldName = "NXM_NX_IP_FRAG"
+			nickName = "ip_frag"
+		case openflow13.NXM_NX_IPV6_LABEL:
+			fieldName = "NXM_NX_IPV6_LABEL"
+			nickName = "ipv6_label"
+		case openflow13.NXM_NX_IP_ECN:
+			fieldName = "NXM_NX_IP_ECN"
+			nickName = "ip_ecn"
+		case openflow13.NXM_NX_IP_TTL:
+			fieldName = "NXM_NX_IP_TTL"
+			nickName = "nw_ttl"
+		case openflow13.NXM_NX_MPLS_TTL:
+			fieldName = "NXM_NX_MPLS_TTL"
+			nickName = "mpls_ttl"
+		case openflow13.NXM_NX_TUN_IPV4_SRC:
+			fieldName = "NXM_NX_TUN_IPV4_SRC"
+			nickName = "nw_src"
+		case openflow13.NXM_NX_TUN_IPV4_DST:
+			fieldName = "NXM_NX_TUN_IPV4_DST"
+			nickName = "nw_dst"
+		case openflow13.NXM_NX_PKT_MARK:
+			fieldName = "NXM_NX_PKT_MARK"
+			nickName = "pkt_mark"
+		case openflow13.NXM_NX_TCP_FLAGS:
+			fieldName = "NXM_NX_TCP_FLAGS"
+			nickName = "tcp_flags"
+		case openflow13.NXM_NX_CONJ_ID:
+			fieldName = "NXM_NX_CONJ_ID"
+			nickName = "conj_id"
+		case openflow13.NXM_NX_TUN_GBP_ID:
+			fieldName = "NXM_NX_TUN_GBP_ID"
+			nickName = "tun_gbp_id"
+		case openflow13.NXM_NX_TUN_GBP_FLAGS:
+			fieldName = "NXM_NX_TUN_GBP_FLAGS"
+			nickName = "tun_gbp_flags"
+		case openflow13.NXM_NX_TUN_FLAGS:
+			fieldName = "NXM_NX_TUN_FLAGS"
+			nickName = "tun_flags"
+		case openflow13.NXM_NX_CT_STATE:
+			fieldName = "NXM_NX_CT_STATE"
+			nickName = "ct_state"
+		case openflow13.NXM_NX_CT_ZONE:
+			fieldName = "NXM_NX_CT_ZONE"
+			nickName = "ct_zone"
+		case openflow13.NXM_NX_CT_MARK:
+			fieldName = "NXM_NX_CT_MARK"
+			nickName = "ct_mark"
+		case openflow13.NXM_NX_CT_LABEL:
+			fieldName = "NXM_NX_CT_LABEL"
+			nickName = "ct_label"
+		case openflow13.NXM_NX_TUN_IPV6_SRC:
+			fieldName = "NXM_NX_TUN_IPV6_SRC"
+			nickName = "tun_ipv6_src"
+		case openflow13.NXM_NX_TUN_IPV6_DST:
+			fieldName = "NXM_NX_TUN_IPV6_DST"
+			nickName = "tun_ipv6_dst"
+		case openflow13.NXM_NX_TUN_METADATA0:
+			fallthrough
+		case openflow13.NXM_NX_TUN_METADATA1:
+			fallthrough
+		case openflow13.NXM_NX_TUN_METADATA2:
+			fallthrough
+		case openflow13.NXM_NX_TUN_METADATA3:
+			fallthrough
+		case openflow13.NXM_NX_TUN_METADATA4:
+			fallthrough
+		case openflow13.NXM_NX_TUN_METADATA5:
+			fallthrough
+		case openflow13.NXM_NX_TUN_METADATA6:
+			fallthrough
+		case openflow13.NXM_NX_TUN_METADATA7:
+			num := mf.Field - openflow13.NXM_NX_TUN_METADATA0
+			fieldName = fmt.Sprintf("NXM_NX_TUN_METADATA%d", num)
+			nickName = fmt.Sprintf("tun_metadata%d", num)
+		case openflow13.NXM_NX_CT_NW_PROTO:
+			fieldName = "NXM_NX_CT_NW_PROTO"
+			nickName = "ct_nw_proto"
+		case openflow13.NXM_NX_CT_NW_SRC:
+			fieldName = "NXM_NX_CT_NW_SRC"
+			nickName = "ct_nw_src"
+		case openflow13.NXM_NX_CT_NW_DST:
+			fieldName = "NXM_NX_CT_NW_DST"
+			nickName = "ct_nw_dst"
+		case openflow13.NXM_NX_CT_IPV6_SRC:
+			fieldName = "NXM_NX_CT_IPV6_SRC"
+			nickName = "ct_ipv6_src"
+		case openflow13.NXM_NX_CT_IPV6_DST:
+			fieldName = "NXM_NX_CT_IPV6_DST"
+			nickName = "ct_ipv6_dst"
+		case openflow13.NXM_NX_CT_TP_SRC:
+			fieldName = "NXM_NX_CT_TP_SRC"
+			nickName = "ct_tp_src"
+		case openflow13.NXM_NX_CT_TP_DST:
+			fieldName = "NXM_NX_CT_TP_DST"
+			nickName = "ct_tp_dst"
+		}
+	case openflow13.OXM_CLASS_OPENFLOW_BASIC:
+		switch mf.Field {
+		case openflow13.OXM_FIELD_IN_PORT:
+			fieldName = "OXM_OF_IN_PORT"
+			nickName = "in_port"
+		case openflow13.OXM_FIELD_IN_PHY_PORT:
+			fieldName = "OXM_OF_IN_PHY_PORT"
+			nickName = "phy_in_port"
+		case openflow13.OXM_FIELD_METADATA:
+			fieldName = "OXM_OF_METADATA"
+			nickName = "metadata"
+		case openflow13.OXM_FIELD_ETH_DST:
+			fieldName = "OXM_OF_ETH_DST"
+			nickName = "dl_dst"
+		case openflow13.OXM_FIELD_ETH_SRC:
+			fieldName = "OXM_OF_ETH_SRC"
+			nickName = "dl_src"
+		case openflow13.OXM_FIELD_ETH_TYPE:
+			fieldName = "OXM_OF_ETH_TYPE"
+			nickName = "ether_type"
+		case openflow13.OXM_FIELD_VLAN_VID:
+			fieldName = "OXM_OF_VLAN_VID"
+			nickName = "vlan_vid"
+		case openflow13.OXM_FIELD_VLAN_PCP:
+			fieldName = "OXM_OF_VLAN_PCP"
+			nickName = "vlan_pcp"
+		case openflow13.OXM_FIELD_IP_DSCP:
+			fieldName = "OXM_OF_IP_DSCP"
+			nickName = "ip_dscp"
+		case openflow13.OXM_FIELD_IP_ECN:
+			fieldName = "OXM_OF_IP_ECN"
+			nickName = "ip_ecn"
+		case openflow13.OXM_FIELD_IP_PROTO:
+			fieldName = "OXM_OF_IP_PROTO"
+			nickName = "ip_proto"
+		case openflow13.OXM_FIELD_IPV4_SRC:
+			fieldName = "OXM_OF_IPV4_SRC"
+			nickName = "nw_src"
+		case openflow13.OXM_FIELD_IPV4_DST:
+			fieldName = "OXM_OF_IPV4_DST"
+			nickName = "nw_dst"
+		case openflow13.OXM_FIELD_TCP_SRC:
+			fieldName = "OXM_OF_TCP_SRC"
+			nickName = "tp_src"
+		case openflow13.OXM_FIELD_TCP_DST:
+			fieldName = "OXM_OF_TCP_DST"
+			nickName = "tp_dst"
+		case openflow13.OXM_FIELD_UDP_SRC:
+			fieldName = "OXM_OF_UDP_SRC"
+			nickName = "udp_src"
+		case openflow13.OXM_FIELD_UDP_DST:
+			fieldName = "OXM_OF_UDP_DST"
+			nickName = "udp_dst"
+		case openflow13.OXM_FIELD_SCTP_SRC:
+			fieldName = "OXM_OF_SCTP_SRC"
+			nickName = "sctp_src"
+		case openflow13.OXM_FIELD_SCTP_DST:
+			fieldName = "OXM_OF_SCTP_DST"
+			nickName = "sctp_dst"
+		case openflow13.OXM_FIELD_ICMPV4_TYPE:
+			fieldName = "OXM_OF_ICMPV4_TYPE"
+			nickName = "icmp_type"
+		case openflow13.OXM_FIELD_ICMPV4_CODE:
+			fieldName = "OXM_OF_ICMPV4_CODE"
+			nickName = "icmp_code"
+		case openflow13.OXM_FIELD_ARP_OP:
+			fieldName = "OXM_OF_ARP_OP"
+			nickName = "arp_op"
+		case openflow13.OXM_FIELD_ARP_SPA:
+			fieldName = "OXM_OF_ARP_SPA"
+			nickName = "arp_spa"
+		case openflow13.OXM_FIELD_ARP_TPA:
+			fieldName = "OXM_OF_ARP_TPA"
+			nickName = "arp_tpa"
+		case openflow13.OXM_FIELD_ARP_SHA:
+			fieldName = "OXM_OF_ARP_SHA"
+			nickName = "arp_sha"
+		case openflow13.OXM_FIELD_ARP_THA:
+			fieldName = "OXM_OF_ARP_THA"
+			nickName = "arp_thp"
+		case openflow13.OXM_FIELD_IPV6_SRC:
+			fieldName = "OXM_OF_IPV6_SRC"
+			nickName = "ipv6_src"
+		case openflow13.OXM_FIELD_IPV6_DST:
+			fieldName = "OXM_OF_IPV6_DST"
+			nickName = "ipv6_dst"
+		case openflow13.OXM_FIELD_IPV6_FLABEL:
+			fieldName = "OXM_OF_IPV6_FLABEL"
+			nickName = "ipv6_label"
+		case openflow13.OXM_FIELD_ICMPV6_TYPE:
+			fieldName = "OXM_OF_ICMPV6_TYPE"
+			nickName = "icmpv6_type"
+		case openflow13.OXM_FIELD_ICMPV6_CODE:
+			fieldName = "OXM_OF_ICMPV6_CODE"
+			nickName = "icmpv6_code"
+		case openflow13.OXM_FIELD_IPV6_ND_TARGET:
+			fieldName = "OXM_OF_IPV6_ND_TARGET"
+			nickName = "ipv6_nd_target"
+		case openflow13.OXM_FIELD_IPV6_ND_SLL:
+			fieldName = "OXM_OF_IPV6_ND_SLL"
+			nickName = "ipv6_nd_sll"
+		case openflow13.OXM_FIELD_IPV6_ND_TLL:
+			fieldName = "OXM_OF_IPV6_ND_TLL"
+			nickName = "ipv6_nd_tll"
+		case openflow13.OXM_FIELD_MPLS_LABEL:
+			fieldName = "OXM_OF_MPLS_LABEL"
+			nickName = "mpls_label"
+		case openflow13.OXM_FIELD_MPLS_TC:
+			fieldName = "OXM_OF_MPLS_TC"
+			nickName = "mpls_tc"
+		case openflow13.OXM_FIELD_MPLS_BOS:
+			fieldName = "OXM_OF_MPLS_BOS"
+			nickName = "mpls_bos"
+		case openflow13.OXM_FIELD_PBB_ISID:
+			fieldName = "OXM_OF_PBB_ISID"
+			nickName = "pbb_isid"
+		case openflow13.OXM_FIELD_TUNNEL_ID:
+			fieldName = "OXM_OF_TUNNEL_ID"
+			nickName = "tunnel_id"
+		case openflow13.OXM_FIELD_IPV6_EXTHDR:
+			fieldName = "OXM_OF_IPV6_EXTHDR"
+			nickName = "ipv6_exthdr"
+		}
+	}
+	return fieldName, nickName
+}
+
+func getCTState(mf *openflow13.MatchField) (*CTStatesChecker, error) {
+	data, err := getUint32(mf.Value)
+	if err != nil {
+		return nil, err
+	}
+	mask, err := getUint32(mf.Mask)
+	if err != nil {
+		return nil, err
+	}
+	return &CTStatesChecker{Value: data, Mask: mask}, nil
+}
+
+func getUint8(value util.Message) (uint8, error) {
+	data, err := value.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	return data[0], nil
+}
+
+func getUint16(value util.Message) (uint16, error) {
+	data, err := value.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	if len(data) < 2 {
+		return 0, errors.New("the field value has wrong size to translate to uint16")
+	}
+	return binary.BigEndian.Uint16(data), nil
+}
+
+func getUint32(value util.Message) (uint32, error) {
+	data, err := value.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+	if len(data) < 4 {
+		return 0, errors.New("the field value has wrong size to translate to uint32")
+	}
+	return binary.BigEndian.Uint32(data), nil
+}
+
+func getNXReg(mf *openflow13.MatchField) (*NXRegister, error) {
+	value := mf.Value
+	data, err := getUint32(value)
+	if err != nil {
+		return nil, err
+	}
+
+	id := int(mf.Field)
+	reg := &NXRegister{
+		ID:   id,
+		Data: data,
+	}
+	if mf.HasMask {
+		maskData, err := getUint32(mf.Mask)
+		if err != nil {
+			return nil, err
+		}
+		rng := getNXRangeFromUint32Mask(maskData)
+		reg.Range = rng
+	}
+	return reg, nil
+}
+
+func getNXRangeFromUint32Mask(mask uint32) *openflow13.NXRange {
+	leftMask := uint32(0x80000000)
+	rightMask := uint32(0x1)
+	maxLength := 32
+
+	i := 0
+	var start, end int
+	for i < maxLength {
+		if mask<<i&leftMask != 0 {
+			end = 31 - i
+			break
+		}
+		i++
+	}
+	i = 0
+	for i < maxLength {
+		if mask>>i&rightMask != 0 {
+			start = i
+			break
+		}
+		i++
+	}
+	return openflow13.NewNXRange(start, end)
+}
+
+func GetUint32ValueWithRange(data uint32, rng *openflow13.NXRange) uint32 {
+	start := rng.GetOfs()
+	end := start + rng.GetNbits()
+	leftOfs := 32 - end
+	return data << leftOfs >> (start + leftOfs)
+}
+
+func GetUint64ValueWithRange(data uint64, rng *openflow13.NXRange) uint64 {
+	start := rng.GetOfs()
+	end := start + rng.GetNbits()
+	leftOfs := 64 - end
+	return data << leftOfs >> (start + leftOfs)
+}
+
+func GetUint32ValueWithRangeFromBytes(data []byte, rng *openflow13.NXRange) (uint32, error) {
+	if len(data) <= 4 {
+		uint32Data := binary.BigEndian.Uint32(data)
+		return GetUint32ValueWithRange(uint32Data, rng), nil
+	}
+	startByte := int(rng.GetOfs() / 8)
+	startDiff := startByte * 8
+	endByte := int(rng.GetNbits() + 7/8)
+	if endByte > len(data) {
+		return 0, errors.New("range is larger than data length")
+	}
+	uint32Data := binary.BigEndian.Uint32(data[startByte:endByte])
+	newRange := openflow13.NewNXRange(int(rng.GetOfs())-startDiff, int(rng.GetNbits())-startDiff)
+	return GetUint32ValueWithRange(uint32Data, newRange), nil
+}
+
+func GetUint64ValueWithRangeFromBytes(data []byte, rng *openflow13.NXRange) (uint64, error) {
+	if len(data) <= 8 {
+		uint64Data := binary.BigEndian.Uint64(data)
+		return GetUint64ValueWithRange(uint64Data, rng), nil
+	}
+	startByte := int(rng.GetOfs() / 8)
+	startDiff := startByte * 8
+	endByte := int(rng.GetNbits() + 7/8)
+	if endByte > len(data) {
+		return 0, errors.New("range is larger than data length")
+	}
+	uint64Data := binary.BigEndian.Uint64(data[startByte:endByte])
+	newRange := openflow13.NewNXRange(int(rng.GetOfs())-startDiff, int(rng.GetNbits())-startDiff)
+	return GetUint64ValueWithRange(uint64Data, newRange), nil
+}

--- a/ofctrl/ofPacket.go
+++ b/ofctrl/ofPacket.go
@@ -1,0 +1,174 @@
+package ofctrl
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"net"
+
+	"github.com/contiv/libOpenflow/openflow13"
+	"github.com/contiv/libOpenflow/protocol"
+	"github.com/contiv/libOpenflow/util"
+)
+
+type PacketOut struct {
+	InPort  uint32
+	OutPort uint32
+	Actions []OFAction
+
+	SrcMAC     net.HardwareAddr
+	DstMAC     net.HardwareAddr
+	IPHeader   *protocol.IPv4
+	TCPHeader  *protocol.TCP
+	UDPHeader  *protocol.UDP
+	ICMPHeader *protocol.ICMP
+
+	ARPHeader *protocol.ARP
+}
+
+func (p *PacketOut) GetMessage() util.Message {
+	packetOut := openflow13.NewPacketOut()
+	packetOut.InPort = p.InPort
+	for _, act := range p.Actions {
+		packetOut.AddAction(act.GetActionMessage())
+	}
+	packetOut.Data = p.getEthernetHeader()
+	if p.OutPort > 0 {
+		packetOut.AddAction(openflow13.NewActionOutput(p.OutPort))
+	} else {
+		packetOut.AddAction(openflow13.NewActionOutput(openflow13.P_TABLE))
+	}
+	return packetOut
+}
+
+func (p *PacketOut) getEthernetHeader() *protocol.Ethernet {
+	ethPkt := &protocol.Ethernet{
+		HWDst: p.DstMAC,
+		HWSrc: p.SrcMAC,
+	}
+
+	var data util.Message
+	var ethType uint16
+	if p.ARPHeader != nil {
+		data = p.ARPHeader
+		ethType = 0x0806
+	} else {
+		switch {
+		case p.TCPHeader != nil:
+			p.IPHeader.Protocol = protocol.Type_TCP
+			p.IPHeader.Data = p.TCPHeader
+		case p.UDPHeader != nil:
+			p.IPHeader.Protocol = protocol.Type_UDP
+			p.IPHeader.Data = p.UDPHeader
+		case p.ICMPHeader != nil:
+			p.IPHeader.Protocol = protocol.Type_ICMP
+			p.IPHeader.Data = p.ICMPHeader
+		default:
+			p.IPHeader.Protocol = 0xff
+		}
+		data = p.IPHeader
+		ethType = 0x0800
+	}
+	ethPkt.Ethertype = ethType
+	ethPkt.Data = data
+	return ethPkt
+}
+
+func (p *PacketIn) GetMatches() *Matchers {
+	matches := make([]*MatchField, 0, len(p.Match.Fields))
+	for i := range p.Match.Fields {
+		matches = append(matches, NewMatchField(&p.Match.Fields[i]))
+	}
+	return &Matchers{matches: matches}
+}
+
+func GenerateTCPPacket(srcMAC, dstMAC net.HardwareAddr, srcIP, dstIP net.IP, dstPort, srcPort uint16, tcpFlags *uint8) *PacketOut {
+	tcpHeader := GenerateTCPHeader(dstPort, srcPort, tcpFlags)
+	ipHeader := &protocol.IPv4{
+		Version:        4,
+		IHL:            5,
+		Length:         20 + tcpHeader.Len(),
+		Id:             uint16(rand.Int()),
+		Flags:          0,
+		FragmentOffset: 0,
+		TTL:            64,
+		Protocol:       protocol.Type_TCP,
+		Checksum:       0,
+		NWSrc:          srcIP,
+		NWDst:          dstIP,
+	}
+	pktOut := &PacketOut{
+		SrcMAC:    srcMAC,
+		DstMAC:    dstMAC,
+		IPHeader:  ipHeader,
+		TCPHeader: tcpHeader,
+	}
+
+	return pktOut
+}
+
+func GenerateSimpleIPPacket(srcMAC, dstMAC net.HardwareAddr, srcIP, dstIP net.IP) *PacketOut {
+	icmpHeader := GenerateICMPHeader(nil, nil)
+	ipHeader := &protocol.IPv4{
+		Version:        4,
+		IHL:            5,
+		Length:         20 + icmpHeader.Len(),
+		Id:             uint16(rand.Int()),
+		Flags:          0,
+		FragmentOffset: 0,
+		TTL:            64,
+		Protocol:       protocol.Type_ICMP,
+		Checksum:       0,
+		NWSrc:          srcIP,
+		NWDst:          dstIP,
+	}
+	pktOut := &PacketOut{
+		SrcMAC:     srcMAC,
+		DstMAC:     dstMAC,
+		IPHeader:   ipHeader,
+		ICMPHeader: icmpHeader,
+	}
+	return pktOut
+}
+
+func GenerateTCPHeader(dstPort, srcPort uint16, flags *uint8) *protocol.TCP {
+	header := protocol.NewTCP()
+	if dstPort != 0 {
+		header.PortDst = dstPort
+	} else {
+		header.PortDst = uint16(rand.Uint32())
+	}
+	if srcPort != 0 {
+		header.PortSrc = srcPort
+	} else {
+		header.PortSrc = uint16(rand.Uint32())
+	}
+	header.AckNum = rand.Uint32()
+	header.AckNum = header.AckNum + 1
+	header.HdrLen = 20
+	if flags != nil {
+		header.Code = *flags
+	} else {
+		header.Code = uint8(1 << 1)
+	}
+	return header
+}
+
+func GenerateICMPHeader(icmpType, icmpCode *uint8) *protocol.ICMP {
+	header := protocol.NewICMP()
+	if icmpType != nil {
+		header.Type = *icmpType
+	} else {
+		header.Type = 8
+	}
+	if icmpCode != nil {
+		header.Code = *icmpCode
+	} else {
+		header.Code = 0
+	}
+	identifier := uint16(rand.Uint32())
+	seq := uint16(1)
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint16(data, identifier)
+	binary.BigEndian.PutUint16(data[2:], seq)
+	return header
+}

--- a/ofctrl/ofSwitch.go
+++ b/ofctrl/ofSwitch.go
@@ -272,7 +272,8 @@ func (self *OFSwitch) handleMessages(dpid net.HardwareAddr, msg util.Message) {
 		case openflow13.Type_TlvTableReply:
 			reply := t.VendorData.(*openflow13.TLVTableReply)
 			status := TLVTableStatus(*reply)
-			self.app.TLVMapReplyRcvd(self, &status)
+			self.tlvTableStatus = &status
+			self.app.TLVMapReplyRcvd(self, self.tlvTableStatus)
 		case openflow13.Type_BundleCtrl:
 			result := MessageResult{
 				xID:     t.Header.Xid,

--- a/ofctrl/ofTlvMap.go
+++ b/ofctrl/ofTlvMap.go
@@ -74,3 +74,18 @@ func (s *OFSwitch) RequestTlvMap() error {
 	}
 	return nil
 }
+
+func (s *OFSwitch) ResetFieldLength(field *openflow13.MatchField) *openflow13.MatchField {
+	if s.tlvTableStatus == nil {
+		return field
+	}
+	if field.Field < openflow13.NXM_NX_TUN_METADATA0 || field.Field > openflow13.NXM_NX_TUN_METADATA7 {
+		return field
+	}
+	index := field.Field - openflow13.NXM_NX_TUN_METADATA0
+	m := s.tlvTableStatus.GetTLVMap(uint16(index))
+	if m != nil {
+		field.Length = m.OptLength
+	}
+	return field
+}

--- a/ofctrl/ofTlvMap.go
+++ b/ofctrl/ofTlvMap.go
@@ -1,0 +1,76 @@
+package ofctrl
+
+import (
+	"fmt"
+	"github.com/contiv/libOpenflow/openflow13"
+)
+
+type TLVTableStatus openflow13.TLVTableReply
+
+func (t *TLVTableStatus) GetTLVMap(index uint16) *openflow13.TLVTableMap {
+	for _, m := range t.TlvMaps {
+		if m.Index == index {
+			return m
+		}
+	}
+	return nil
+}
+
+func (t *TLVTableStatus) GetMaxSpace() uint32 {
+	return t.MaxSpace
+}
+
+func (t *TLVTableStatus) GetMaxFields() uint16 {
+	return t.MaxFields
+}
+
+func (t *TLVTableStatus) GetAllocatedResources() (space uint32, indexes []uint16) {
+	for _, m := range t.TlvMaps {
+		space += uint32(m.OptLength)
+		indexes = append(indexes, m.Index)
+	}
+	return
+}
+
+func (t *TLVTableStatus) String() string {
+	value := fmt.Sprintf("max option space=%d max field=%d\n", t.MaxSpace, t.MaxFields)
+	for _, m := range t.TlvMaps {
+		value = fmt.Sprintf("%s%s", value, t.GetTLVMapString(m))
+	}
+	return value
+}
+
+func (t *TLVTableStatus) GetTLVMapString(m *openflow13.TLVTableMap) string {
+	return fmt.Sprintf("TLVMap: class=0x%x,type=0x%x,length=0x%x,match_field=%d", m.OptClass, m.OptType, m.OptLength, m.Index)
+}
+
+func (t *TLVTableStatus) AddTLVMap(m *openflow13.TLVTableMap) {
+	t.TlvMaps = append(t.TlvMaps, m)
+}
+
+func (s *OFSwitch) AddTunnelTLVMap(tlvMaps []*openflow13.TLVTableMap) error {
+	tlvMapMod := openflow13.NewTLVTableMod(openflow13.NXTTMC_ADD, tlvMaps)
+	msg := openflow13.NewTLVTableModMessage(tlvMapMod)
+	return s.Send(msg)
+}
+
+func (s *OFSwitch) DeleteTunnelTLVMap(tlvMaps []*openflow13.TLVTableMap) error {
+	tlvMapMod := openflow13.NewTLVTableMod(openflow13.NXTTMC_DELETE, tlvMaps)
+	msg := openflow13.NewTLVTableModMessage(tlvMapMod)
+	return s.Send(msg)
+}
+
+func (s *OFSwitch) ClearTunnelTLVMap(tlvMaps []*openflow13.TLVTableMap) error {
+	tlvMapMod := openflow13.NewTLVTableMod(openflow13.NXTTMC_CLEAR, tlvMaps)
+	msg := openflow13.NewTLVTableModMessage(tlvMapMod)
+	return s.Send(msg)
+}
+
+func (s *OFSwitch) RequestTlvMap() error {
+	msg := openflow13.NewTLVTableRequest()
+	err := s.Send(msg)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -37,10 +37,14 @@ type OfActor struct {
 	inputTable     *Table
 	nextTable      *Table
 	connectedCount int
+
+	pktInCount     int
+	tlvTableStatus *TLVTableStatus
+	tlvMapCh       chan struct{}
 }
 
 func (o *OfActor) PacketRcvd(sw *OFSwitch, packet *PacketIn) {
-	log.Printf("App: Received packet: %+v", packet)
+	log.Printf("App: Received packet: %+v", packet.Data.Data)
 }
 
 func (o *OfActor) SwitchConnected(sw *OFSwitch) {
@@ -59,6 +63,14 @@ func (o *OfActor) MultipartReply(sw *OFSwitch, rep *openflow13.MultipartReply) {
 func (o *OfActor) SwitchDisconnected(sw *OFSwitch) {
 	log.Printf("App: Switch disconnected: %v", sw.DPID())
 	o.isSwitchConnected = false
+}
+
+func (o *OfActor) TLVMapReplyRcvd(sw *OFSwitch, tlvTableStatus *TLVTableStatus) {
+	log.Printf("App: Receive TLVMapTable reply: %s", tlvTableStatus)
+	o.tlvTableStatus = tlvTableStatus
+	if o.tlvMapCh != nil {
+		close(o.tlvMapCh)
+	}
 }
 
 var ofActor OfActor
@@ -140,7 +152,7 @@ func ofctlDumpFlowMatch(brName string, tableId int, matchStr, actStr string) boo
 
 // Test if OVS switch connects successfully
 func TestMain(m *testing.M) {
-	// Create a controller
+	//Create a controller
 	ctrler = NewController(&ofActor)
 	ofActor2 = OfActor{}
 	ctrler2 = NewController(&ofActor2)
@@ -204,15 +216,16 @@ func TestMain(m *testing.M) {
 	exitCode := m.Run()
 
 	// delete the bridge
-	err = ovsDriver.DeleteBridge("ovsbr11")
-	if err != nil {
-		log.Fatalf("Error deleting the bridge. Err: %v", err)
-	}
+	for _, br := range []string{
+		"ovsbr11",
+		"ovsbr12",
+	} {
+		err = ovsDriver.DeleteBridge(br)
+		if err != nil {
+			log.Fatalf("Error deleting the bridge. Err: %v", err)
+		}
 
-	//err = ovsDriver2.DeleteBridge("ovsbr12")
-	//if err != nil {
-	//	log.Fatalf("Error deleting the bridge. Err: %v", err)
-	//}
+	}
 
 	os.Exit(exitCode)
 }
@@ -767,7 +780,8 @@ func TestOFSwitch_DumpFlowStats(t *testing.T) {
 
 	cookieID := roundID | categoryID
 	cookieMask := uint64(0xffffff)
-	stats := ofActor2.Switch.DumpFlowStats(cookieID, cookieMask, nil, nil)
+	stats, err := ofActor2.Switch.DumpFlowStats(cookieID, cookieMask, nil, nil)
+	require.Nil(t, err)
 	if stats == nil {
 		t.Fatalf("Failed to dump flows")
 	}
@@ -803,7 +817,7 @@ func TestReconnectOFSwitch(t *testing.T) {
 		}
 		ctrl.Delete()
 	}()
-	assert.Equal(t, ofActor2.connectedCount, 1)
+	assert.Equal(t, app.connectedCount, 1)
 	go func() {
 		ovsBr.DeleteBridge(brName)
 		select {
@@ -912,7 +926,7 @@ func TestBundles(t *testing.T) {
 	fm4, err := flow4.GetBundleMessage(openflow13.FC_ADD)
 	require.Nil(t, err, "Failed to generate FlowMod from Flow")
 	message, _ := tx3.createBundleAddMessage(fm4)
-	message.Xid = uint32(100001)
+	message.Header.Xid = uint32(100001)
 	tx3.ofSwitch.Send(message)
 	count, err = tx3.Complete()
 	require.Nil(t, err, fmt.Sprintf("Failed to find addMesssage errors transaction: %v", err))
@@ -1016,8 +1030,6 @@ func TestNotes(t *testing.T) {
 
 func TestNewFlowActionAPIs(t *testing.T) {
 	ofApp := ofActor2
-
-	// Test action: load mac to src mac
 	brName := ovsDriver2.OvsBridgeName
 	log.Infof("Enable monitor flows on table %d in bridge %s", ofApp.inputTable.TableId, brName)
 	ofApp.Switch.EnableMonitor()
@@ -1330,6 +1342,72 @@ func TestNewFlowActionAPIs(t *testing.T) {
 		"group:1")
 	group1.Delete()
 	verifyGroup(t, brName, group1, "select", "bucket=weight:50,actions=ct(commit,nat(src=10.0.0.240,random))", false)
+}
+
+func TestSetTunnelMetadata(t *testing.T) {
+	ofApp := ofActor2
+	brName := ovsDriver2.OvsBridgeName
+	log.Infof("Enable monitor flows on table %d in bridge %s", ofApp.inputTable.TableId, brName)
+	ofApp.Switch.EnableMonitor()
+
+	ch := make(chan struct{})
+	ofActor.tlvMapCh = ch
+	err := ofActor.Switch.RequestTlvMap()
+	require.Nil(t, err)
+	<-ch
+
+	tlvMap := &openflow13.TLVTableMap{OptClass: 0xff01, OptType: 0, OptLength: 4, Index: 0}
+	err = ofApp.Switch.AddTunnelTLVMap([]*openflow13.TLVTableMap{tlvMap})
+	require.Nil(t, err)
+
+	inPort9 := uint32(111)
+	flow14 := &Flow{
+		Table: ofApp.inputTable,
+		Match: FlowMatch{
+			Priority:  100,
+			Ethertype: 0x0800,
+			InputPort: inPort9,
+		},
+	}
+	rng14 := openflow13.NewNXRange(8, 15)
+	loadReg2, err := NewNXLoadAction("NXM_NX_TUN_METADATA0", uint64(0x12), rng14)
+	require.Nil(t, err)
+	flow14.ApplyActions([]OFAction{loadReg2})
+	verifyNewFlowInstallAndDelete(t, flow14, brName, ofApp.inputTable.TableId,
+		"priority=100,ip,in_port=111",
+		"set_field:0x1200/0xff00->tun_metadata0")
+
+	inPort10 := uint32(112)
+	rng15 := openflow13.NewNXRange(8, 23)
+
+	flow15 := &Flow{
+		Table: ofApp.inputTable,
+		Match: FlowMatch{
+			Priority:  100,
+			InputPort: inPort10,
+			Ethertype: 0x0800,
+			TunMetadatas: []*NXTunMetadata{
+				{
+					ID:    0,
+					Data:  uint32(0x34),
+					Range: rng15,
+				}},
+		},
+	}
+	flow15.Goto(ofApp.nextTable.TableId)
+	verifyNewFlowInstallAndDelete(t, flow15, brName, ofApp.inputTable.TableId,
+		"priority=100,ip,tun_metadata0=0x3400/0xffff00,in_port=112",
+		"goto_table:1")
+
+	err = ofApp.Switch.DeleteTunnelTLVMap([]*openflow13.TLVTableMap{tlvMap})
+	require.Nil(t, err)
+}
+
+func TestGetMaskBytes(t *testing.T) {
+	rngBytes := getMaskBytes(8, 16)
+	assert.Equal(t, 4, len(rngBytes))
+	maskString := fmt.Sprintf("0x%x", rngBytes)
+	assert.Equal(t, "0x00ffff00", maskString)
 }
 
 func testNXExtensionNote(ofApp OfActor, ovsBr *OvsDriver, t *testing.T) {

--- a/ofctrl/ofctrl_test.go
+++ b/ofctrl/ofctrl_test.go
@@ -78,7 +78,7 @@ var ctrler *Controller
 var ovsDriver *OvsDriver
 
 // Controller/Application/ovsBr work on clientMode
-var ofActor2 OfActor
+var ofActor2 *OfActor
 var ctrler2 *Controller
 var ovsDriver2 *OvsDriver
 
@@ -154,8 +154,8 @@ func ofctlDumpFlowMatch(brName string, tableId int, matchStr, actStr string) boo
 func TestMain(m *testing.M) {
 	//Create a controller
 	ctrler = NewController(&ofActor)
-	ofActor2 = OfActor{}
-	ctrler2 = NewController(&ofActor2)
+	ofActor2 = new(OfActor)
+	ctrler2 = NewController(ofActor2)
 
 	// start listening
 	go ctrler.Listen(":6733")
@@ -1016,7 +1016,7 @@ func createFlow(t *testing.T, mac, ip string) *Flow {
 
 // Test Nicira extensions for match field and actions
 func TestNXExtension(t *testing.T) {
-	testNXExtensionsWithOFApplication(ofActor, ovsDriver, t)
+	testNXExtensionsWithOFApplication(&ofActor, ovsDriver, t)
 	testNXExtensionsWithOFApplication(ofActor2, ovsDriver2, t)
 }
 
@@ -1351,14 +1351,15 @@ func TestSetTunnelMetadata(t *testing.T) {
 	ofApp.Switch.EnableMonitor()
 
 	ch := make(chan struct{})
-	ofActor.tlvMapCh = ch
-	err := ofActor.Switch.RequestTlvMap()
+	ofApp.tlvMapCh = ch
+	err := ofApp.Switch.RequestTlvMap()
 	require.Nil(t, err)
 	<-ch
 
 	tlvMap := &openflow13.TLVTableMap{OptClass: 0xff01, OptType: 0, OptLength: 4, Index: 0}
 	err = ofApp.Switch.AddTunnelTLVMap([]*openflow13.TLVTableMap{tlvMap})
 	require.Nil(t, err)
+	ofApp.Switch.tlvTableStatus.AddTLVMap(tlvMap)
 
 	inPort9 := uint32(111)
 	flow14 := &Flow{
@@ -1394,10 +1395,15 @@ func TestSetTunnelMetadata(t *testing.T) {
 				}},
 		},
 	}
+	rng16 := openflow13.NewNXRange(28, 31)
+	moveAction, err := NewNXMoveAction("NXM_NX_TUN_METADATA0", "NXM_NX_REG0", rng16, rng16)
+	require.Nil(t, err)
+	ofApp.Switch.ResetFieldLength(moveAction.SrcField)
+	flow15.ApplyActions([]OFAction{moveAction})
 	flow15.Goto(ofApp.nextTable.TableId)
 	verifyNewFlowInstallAndDelete(t, flow15, brName, ofApp.inputTable.TableId,
 		"priority=100,ip,tun_metadata0=0x3400/0xffff00,in_port=112",
-		"goto_table:1")
+		"move:NXM_NX_TUN_METADATA0[28..31]->NXM_NX_REG0[28..31],goto_table:1")
 
 	err = ofApp.Switch.DeleteTunnelTLVMap([]*openflow13.TLVTableMap{tlvMap})
 	require.Nil(t, err)
@@ -1410,7 +1416,7 @@ func TestGetMaskBytes(t *testing.T) {
 	assert.Equal(t, "0x00ffff00", maskString)
 }
 
-func testNXExtensionNote(ofApp OfActor, ovsBr *OvsDriver, t *testing.T) {
+func testNXExtensionNote(ofApp *OfActor, ovsBr *OvsDriver, t *testing.T) {
 	brName := ovsBr.OvsBridgeName
 	log.Infof("Enable monitor flows on Table %d in bridge %s", ofApp.inputTable.TableId, brName)
 	ofApp.Switch.EnableMonitor()
@@ -1431,7 +1437,7 @@ func testNXExtensionNote(ofApp OfActor, ovsBr *OvsDriver, t *testing.T) {
 
 }
 
-func testNXExtensionLearn(ofApp OfActor, ovsBr *OvsDriver, t *testing.T) {
+func testNXExtensionLearn(ofApp *OfActor, ovsBr *OvsDriver, t *testing.T) {
 	brName := ovsBr.OvsBridgeName
 	log.Infof("Enable monitor flows on Table %d in bridge %s", ofApp.inputTable.TableId, brName)
 	ofApp.Switch.EnableMonitor()
@@ -1487,7 +1493,7 @@ func testNXExtensionLearn(ofApp OfActor, ovsBr *OvsDriver, t *testing.T) {
 
 }
 
-func testNXExtensionsWithOFApplication(ofApp OfActor, ovsBr *OvsDriver, t *testing.T) {
+func testNXExtensionsWithOFApplication(ofApp *OfActor, ovsBr *OvsDriver, t *testing.T) {
 	// Test action: load mac to src mac
 	brName := ovsBr.OvsBridgeName
 	log.Infof("Enable monitor flows on table %d in bridge %s", ofApp.inputTable.TableId, brName)

--- a/ofctrl/ofpacket_test.go
+++ b/ofctrl/ofpacket_test.go
@@ -1,0 +1,167 @@
+package ofctrl
+
+import (
+	"github.com/contiv/libOpenflow/openflow13"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"net"
+	"testing"
+)
+
+type packetApp struct {
+	*OfActor
+	pktCh chan *PacketIn
+}
+
+func (p *packetApp) PacketRcvd(sw *OFSwitch, pkt *PacketIn) {
+	p.pktInCount += 1
+	p.pktCh <- pkt
+}
+
+func TestGetNXRangeFromUint32Mask(t *testing.T) {
+	r := openflow13.NewNXRange(0, 4)
+	oriOfsNbits := r.ToOfsBits()
+	mask := r.ToUint32Mask()
+	r2 := getNXRangeFromUint32Mask(mask)
+	newOfsNbits := r2.ToOfsBits()
+	assert.Equal(t, oriOfsNbits, newOfsNbits)
+}
+
+func TestPacketIn_PacketOut(t *testing.T) {
+	app := new(packetApp)
+	app.OfActor = new(OfActor)
+	app.pktCh = make(chan *PacketIn)
+	ctrl := NewController(app)
+	brName := "br4pkt"
+	ovsBr := prepareContollerAndSwitch(t, app.OfActor, ctrl, brName)
+	defer func() {
+		if err := ovsBr.DeleteBridge(brName); err != nil {
+			t.Errorf("Failed to delete br %s: %v", brName, err)
+		}
+		ctrl.Delete()
+	}()
+
+	assert.Equal(t, 0, app.pktInCount)
+	testPacketInOut(t, app, brName)
+	assert.Equal(t, 1, app.pktInCount)
+}
+
+func testPacketInOut(t *testing.T, ofApp *packetApp, brName string) {
+	log.Infof("Enable monitor flows on table %d in bridge %s", ofApp.inputTable.TableId, brName)
+	ofApp.Switch.EnableMonitor()
+
+	ofSwitch := ofApp.Switch
+
+	srcMAC, _ := net.ParseMAC("11:22:33:44:55:66")
+	dstMAC, _ := net.ParseMAC("66:55:44:33:22:11")
+	srcIP := net.ParseIP("1.1.1.2")
+	dstIP := net.ParseIP("2.2.2.1")
+	dstPort := uint16(1234)
+
+	table0 := ofSwitch.DefaultTable()
+	table1 := ofApp.nextTable
+	flow0 := &Flow{
+		Table: table0,
+		Match: FlowMatch{
+			Priority: 100,
+		},
+	}
+	flow0.ApplyActions([]OFAction{
+		NewResubmit(nil, &table1.TableId),
+	})
+	flow0.Send(openflow13.FC_ADD)
+
+	flow1 := &Flow{
+		Table: table1,
+		Match: FlowMatch{
+			Priority:   100,
+			Ethertype:  0x0800,
+			MacSa:      &srcMAC,
+			MacDa:      &dstMAC,
+			IpSa:       &srcIP,
+			IpDa:       &dstIP,
+			TcpDstPort: dstPort,
+		},
+	}
+	rng0 := openflow13.NewNXRange(0, 15)
+	rng1 := openflow13.NewNXRange(16, 31)
+	rng2 := openflow13.NewNXRange(8, 23)
+	act1, err := NewNXLoadAction("NXM_NX_REG0", uint64(0x1234), rng0)
+	require.Nil(t, err)
+	act2, err := NewNXLoadAction("NXM_NX_REG0", uint64(0x5678), rng1)
+	require.Nil(t, err)
+	act3, err := NewNXLoadAction("NXM_NX_REG1", uint64(0xaaaa), rng2)
+	require.Nil(t, err)
+	expectTunDst := net.ParseIP("10.10.10.10")
+	act5 := &SetTunnelDstAction{IP: expectTunDst}
+	cxControllerAct := &NXController{ControllerID: ofSwitch.ctrlID}
+	flow1.ApplyActions([]OFAction{act1, act2, act3, act5, cxControllerAct})
+	flow1.Send(openflow13.FC_ADD)
+
+	act4, err := NewNXLoadAction("NXM_NX_REG3", uint64(0xaaaa), rng2)
+	packetOut := generateTCPPacketOut(srcMAC, dstMAC, srcIP, dstIP, dstPort, 0, nil, []OFAction{act4})
+	ofSwitch.Send(packetOut.GetMessage())
+
+	pktIn := <-ofApp.pktCh
+	matchers := pktIn.GetMatches()
+	reg0Match := matchers.GetMatchByName("NXM_NX_REG0")
+	assert.NotNil(t, reg0Match)
+	reg0Value, ok := reg0Match.GetValue().(*NXRegister)
+	assert.True(t, ok)
+	reg0prev := GetUint32ValueWithRange(reg0Value.Data, rng0)
+	assert.Equal(t, uint32(0x1234), reg0prev)
+	reg0last := GetUint32ValueWithRange(reg0Value.Data, rng1)
+	assert.Equal(t, uint32(0x5678), reg0last)
+	reg1Match := matchers.GetMatchByName("NXM_NX_REG1")
+	assert.NotNil(t, reg1Match)
+	reg1Value, ok := reg1Match.GetValue().(*NXRegister)
+	assert.True(t, ok)
+	reg1prev := GetUint32ValueWithRange(reg1Value.Data, rng2)
+	assert.Equal(t, uint32(0xaaaa), reg1prev)
+	reg2Match := matchers.GetMatchByName("NXM_NX_REG2")
+	assert.Nil(t, reg2Match)
+	tunDstMatch := matchers.GetMatchByName("NXM_NX_TUN_IPV4_DST")
+	assert.NotNil(t, tunDstMatch)
+	tunDst := tunDstMatch.GetValue().(net.IP)
+	assert.Equal(t, expectTunDst, tunDst)
+}
+
+func generateTCPPacketOut(srcMAC, dstMAC net.HardwareAddr, srcIP net.IP, dstIP net.IP, dstPort, srcPort uint16, outputPort *uint32, actions []OFAction) *PacketOut {
+	var outPort uint32
+	if outputPort == nil {
+		outPort = openflow13.P_TABLE
+	} else {
+		outPort = *outputPort
+	}
+	if dstPort == 0 {
+		dstPort = uint16(rand.Uint32())
+	}
+	if srcPort == 0 {
+		srcPort = uint16(rand.Uint32())
+	}
+	pktOut := GenerateTCPPacket(srcMAC, dstMAC, srcIP, dstIP, dstPort, srcPort, nil)
+	pktOut.InPort = openflow13.P_CONTROLLER
+	pktOut.OutPort = outPort
+	if actions != nil {
+		pktOut.Actions = actions
+	}
+	return pktOut
+}
+
+func generatePacketOut(srcMAC net.HardwareAddr, dstMAC net.HardwareAddr, srcIP net.IP, dstIP net.IP, outputPort *uint32, actions []OFAction) *PacketOut {
+	var outPort uint32
+	if outputPort == nil {
+		outPort = openflow13.P_TABLE
+	} else {
+		outPort = *outputPort
+	}
+	pktOut := GenerateSimpleIPPacket(srcMAC, dstMAC, srcIP, dstIP)
+	pktOut.InPort = openflow13.P_CONTROLLER
+	pktOut.OutPort = outPort
+	if actions != nil {
+		pktOut.Actions = actions
+	}
+	return pktOut
+}


### PR DESCRIPTION
1. Add support to send packet to controller with a provided ID.
2. ofnet sets a Controller ID after connected to the Switch.
3. Add tlv-map relavant actions to support setting Geneve Header.