### PR TITLE
Fix a deadlock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14
 	github.com/cenkalti/hub v1.0.1-0.20140529221144-7be60e186e66 // indirect
 	github.com/cenkalti/rpc2 v0.0.0-20140912135055-44d0d95e4f52 // indirect
-	github.com/contiv/libOpenflow v0.0.0-20200728044739-7c6534390721
+	github.com/contiv/libOpenflow v0.0.0-20201014051314-c1702744526c
 	github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cenkalti/rpc2 v0.0.0-20140912135055-44d0d95e4f52 h1:LnaEnQZECBs+zizOd
 github.com/cenkalti/rpc2 v0.0.0-20140912135055-44d0d95e4f52/go.mod h1:v2npkhrXyk5BCnkNIiPdRI23Uq6uWPUQGL2hnRcRr/M=
 github.com/contiv/libOpenflow v0.0.0-20200728044739-7c6534390721 h1:kYk8terl1B/Nw1YsQwL/EQ6DKa0tpVeh2M8gSmbSAHI=
 github.com/contiv/libOpenflow v0.0.0-20200728044739-7c6534390721/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
+github.com/contiv/libOpenflow v0.0.0-20201014051314-c1702744526c h1:JroumMoYWz73Oxwmy9JAXwii8jsayVw0HxKnbfxj/0o=
+github.com/contiv/libOpenflow v0.0.0-20201014051314-c1702744526c/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358 h1:AiA9SKyNXulsU7aAnyka3UFHYOIH00A9HvdIRnDXlg0=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358/go.mod h1:+qKEHaNVPj+wrn5st7TEFH9wcUWCJq5ZBvVKPQwzAeg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/ofctrl/ofSwitch.go
+++ b/ofctrl/ofSwitch.go
@@ -32,9 +32,7 @@ import (
 )
 
 const (
-	// The default BUNDLE_IDLE_TIMEOUT is 10s and we need wait a bit
-	// longer to overcome the timer difference.
-	messageTimeout = 13 * time.Second
+	messageTimeout = 10 * time.Second
 	PC_NO_FLOOD    = 1 << 4
 )
 
@@ -462,15 +460,7 @@ func (self *OFSwitch) publishMessage(xID uint32, result MessageResult) {
 		defer self.txLock.Unlock()
 		ch, found := self.txChans[xID]
 		if found {
-			select {
-			case ch <- result:
-			case <-time.After(messageTimeout):
-				// If the receiver does not accept the message after 10s
-				// we just drop the message. Since both sender and receiver
-				// are in Go world, there should not be 10s idle in theory.
-				// The receiver will also not wait for a message longer than
-				// messageTimeout.
-			}
+			ch <- result
 		}
 	}()
 }

--- a/ofctrl/ofSwitch.go
+++ b/ofctrl/ofSwitch.go
@@ -32,7 +32,9 @@ import (
 )
 
 const (
-	messageTimeout = 10 * time.Second
+	// The default BUNDLE_IDLE_TIMEOUT is 10s and we need wait a bit
+	// longer to overcome the timer difference.
+	messageTimeout = 13 * time.Second
 	PC_NO_FLOOD    = 1 << 4
 )
 
@@ -460,7 +462,15 @@ func (self *OFSwitch) publishMessage(xID uint32, result MessageResult) {
 		defer self.txLock.Unlock()
 		ch, found := self.txChans[xID]
 		if found {
-			ch <- result
+			select {
+			case ch <- result:
+			case <-time.After(messageTimeout):
+				// If the receiver does not accept the message after 10s
+				// we just drop the message. Since both sender and receiver
+				// are in Go world, there should not be 10s idle in theory.
+				// The receiver will also not wait for a message longer than
+				// messageTimeout.
+			}
 		}
 	}()
 }

--- a/ofctrl/transaction.go
+++ b/ofctrl/transaction.go
@@ -200,9 +200,9 @@ func (tx *Transaction) Commit() error {
 		return fmt.Errorf("transaction %d is not complete", tx.ID)
 	}
 	defer func() {
+		tx.ofSwitch.unSubscribeMessage(tx.ID)
 		close(tx.controlReplyCh)
 		close(tx.controlIntCh)
-		tx.ofSwitch.unSubscribeMessage(tx.ID)
 	}()
 	msg := tx.newBundleControlMessage(openflow13.OFPBCT_COMMIT_REQUEST)
 	if err := tx.sendControlRequest(msg.Header.Xid, msg); err != nil {

--- a/ofctrl/transaction.go
+++ b/ofctrl/transaction.go
@@ -6,13 +6,13 @@ package ofctrl
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/contiv/libOpenflow/openflow13"
 	"github.com/contiv/libOpenflow/util"
+	log "github.com/sirupsen/logrus"
 )
 
 type TransactionType uint16
@@ -53,8 +53,8 @@ func (self *OFSwitch) NewTransaction(flag TransactionType) *Transaction {
 		tx.flag = flag
 	}
 	tx.ofSwitch = self
-	tx.controlReplyCh = make(chan MessageResult)
-	tx.controlIntCh = make(chan MessageResult)
+	tx.controlReplyCh = make(chan MessageResult, 10)
+	tx.controlIntCh = make(chan MessageResult, 1)
 	return tx
 }
 
@@ -120,25 +120,25 @@ func (tx *Transaction) createBundleAddFlowMessage(flowMod *openflow13.FlowMod) (
 func (tx *Transaction) listenReply() {
 	for {
 		select {
-		case reply := <-tx.controlReplyCh:
-			if reply.xID == 0 {
+		case reply, ok := <-tx.controlReplyCh:
+			if !ok { // controlReplyCh closed.
 				return
-			} else {
-				switch reply.msgType {
-				case BundleControlMessage:
-					tx.controlIntCh <- reply
-				case BundleAddMessage:
-					if !reply.succeed {
-						// Remove failed add message from successAdd.
-						tx.lock.Lock()
-						delete(tx.successAdd, reply.xID)
-						tx.lock.Unlock()
-					}
+			}
+			switch reply.msgType {
+			case BundleControlMessage:
+				select {
+				case tx.controlIntCh <- reply:
+				case <-time.After(messageTimeout):
+					log.Warningln("BundleControlMessage reply message accept timeout")
+				}
+			case BundleAddMessage:
+				if !reply.succeed {
+					// Remove failed add message from successAdd.
+					tx.lock.Lock()
+					delete(tx.successAdd, reply.xID)
+					tx.lock.Unlock()
 				}
 			}
-		case <-time.After(messageTimeout):
-			log.Println("Bundle receives no messages from OVS for 10s, close the channel")
-			return
 		}
 	}
 }
@@ -154,6 +154,7 @@ func (tx *Transaction) Begin() error {
 	err := tx.sendControlRequest(message.Header.Xid, message)
 	if err != nil {
 		tx.ofSwitch.unSubscribeMessage(tx.ID)
+		close(tx.controlReplyCh)
 		return err
 	}
 	return nil
@@ -202,7 +203,6 @@ func (tx *Transaction) Commit() error {
 	defer func() {
 		tx.ofSwitch.unSubscribeMessage(tx.ID)
 		close(tx.controlReplyCh)
-		close(tx.controlIntCh)
 	}()
 	msg := tx.newBundleControlMessage(openflow13.OFPBCT_COMMIT_REQUEST)
 	if err := tx.sendControlRequest(msg.Header.Xid, msg); err != nil {
@@ -217,9 +217,8 @@ func (tx *Transaction) Abort() error {
 		return fmt.Errorf("transaction %d is not complete", tx.ID)
 	}
 	defer func() {
-		close(tx.controlReplyCh)
-		close(tx.controlIntCh)
 		tx.ofSwitch.unSubscribeMessage(tx.ID)
+		close(tx.controlReplyCh)
 	}()
 	msg := tx.newBundleControlMessage(openflow13.OFPBCT_DISCARD_REQUEST)
 	if err := tx.sendControlRequest(msg.Header.Xid, msg); err != nil {


### PR DESCRIPTION
When OFPBFC_TIMEOUT happened, listenReply would return and
there was no other consumer for `tx.controlReplyCh`, and OVS
would also send a timeout message to agent so publishMessage
would be called. However, the channel hadn't been removed
from txChans so it would be stuck in `ch <- result` forever.

This commit ensures controlReplyCh is always available to
be pushed to fix deadlock. controlReplyCh and intCh are also
added a buffer to reduce timeout wait impact.

Signed-off-by: Weiqiang Tang <weiqiangt@vmware.com>